### PR TITLE
use local version of zeroclipboard movie

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,34 +220,49 @@
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>
-                	<groupId>org.eclipse.m2e</groupId>
-                	<artifactId>lifecycle-mapping</artifactId>
-                	<version>1.0.0</version>
-                	<configuration>
-                		<lifecycleMappingMetadata>
-                			<pluginExecutions>
-                				<pluginExecution>
-                					<pluginExecutionFilter>
-                						<groupId>
-                							com.github.skwakman.nodejs-maven-plugin
-                						</groupId>
-                						<artifactId>
-                							nodejs-maven-plugin
-                						</artifactId>
-                						<versionRange>
-                							[1.0.3,)
-                						</versionRange>
-                						<goals>
-                							<goal>extract</goal>
-                						</goals>
-                					</pluginExecutionFilter>
-                					<action>
-                						<ignore></ignore>
-                					</action>
-                				</pluginExecution>
-                			</pluginExecutions>
-                		</lifecycleMappingMetadata>
-                	</configuration>
+                  <groupId>org.eclipse.m2e</groupId>
+                  <artifactId>lifecycle-mapping</artifactId>
+                  <version>1.0.0</version>
+                  <configuration>
+                    <lifecycleMappingMetadata>
+                      <pluginExecutions>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>
+                              com.github.skwakman.nodejs-maven-plugin
+                            </groupId>
+                            <artifactId>
+                              nodejs-maven-plugin
+                            </artifactId>
+                            <versionRange>
+                              [1.0.3,)
+                            </versionRange>
+                            <goals>
+                              <goal>extract</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore></ignore>
+                          </action>
+                        </pluginExecution>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>
+                              wagon-maven-plugin
+                            </artifactId>
+                            <versionRange>[1.0,)</versionRange>
+                            <goals>
+                              <goal>download-single</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore></ignore>
+                          </action>
+                        </pluginExecution>
+                      </pluginExecutions>
+                    </lifecycleMappingMetadata>
+                  </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -434,6 +449,33 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- see README in the directory referenced below -->
+            <id>download-zeroclipboard</id>
+            <activation>
+                <file><missing>src/main/webapp/assets/img/zeroclipboard/ZeroClipboard.swf</missing></file>
+            </activation>
+            <build><plugins><plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>wagon-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>download-zeroclipboard</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>download-single</goal>
+                        </goals>
+                        <configuration>
+                            <url>http://cdnjs.cloudflare.com</url>
+                            <fromFile>/ajax/libs/zeroclipboard/1.3.5/ZeroClipboard.swf</fromFile>
+                            <toDir>src/main/webapp/assets/img/zeroclipboard/</toDir>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin></plugins></build>
+        </profile>
+
     </profiles>
 
 </project>

--- a/src/main/webapp/assets/img/zeroclipboard/.gitignore
+++ b/src/main/webapp/assets/img/zeroclipboard/.gitignore
@@ -1,0 +1,1 @@
+ZeroClipboard.swf

--- a/src/main/webapp/assets/img/zeroclipboard/README.md
+++ b/src/main/webapp/assets/img/zeroclipboard/README.md
@@ -1,0 +1,41 @@
+
+For the clipboard to work, the ZeroClipboard.swf artifact (v1.3.5) needs to be 
+downloaded and installed in this directory. Maven will do this automatically for
+you on first run and thereafter use the downloaded version.
+
+If you do not wish to have it, simply create an empty file with that name in this dir.
+
+You can download it manually from:
+
+    http://cdnjs.cloudflare.com/ajax/libs/zeroclipboard/1.3.5/ZeroClipboard.swf
+
+It can be built from source using a free toolchain as described at 
+
+    https://github.com/zeroclipboard/zeroclipboard/blob/master/CONTRIBUTING.md .
+
+It is not checked in because binary artifacts should not be included in source releases
+due to Apache policies. This project is not currently set up to use bower/npm which would
+do the same thing, so instead we follow this process. See also ZeroClipboard.js.
+
+ZeroClipboard is used under the MIT license.
+
+This description file is part of the Apache Brooklyn project.
+
+----
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+

--- a/src/main/webapp/assets/js/view/entity-config.js
+++ b/src/main/webapp/assets/js/view/entity-config.js
@@ -28,7 +28,7 @@ define([
 ], function (_, $, Backbone, Util, ZeroClipboard, ViewUtils, ConfigSummary, ConfigHtml, ConfigNameHtml) {
 
     // TODO consider extracting all such usages to a shared ZeroClipboard wrapper?
-    ZeroClipboard.config({ moviePath: '//cdnjs.cloudflare.com/ajax/libs/zeroclipboard/1.3.1/ZeroClipboard.swf' });
+    ZeroClipboard.config({ moviePath: '/assets/img/zeroclipboard/ZeroClipboard.swf' });
 
     var configHtml = _.template(ConfigHtml),
         configNameHtml = _.template(ConfigNameHtml);

--- a/src/main/webapp/assets/js/view/entity-sensors.js
+++ b/src/main/webapp/assets/js/view/entity-sensors.js
@@ -28,7 +28,7 @@ define([
 ], function (_, $, Backbone, Util, ZeroClipboard, ViewUtils, SensorSummary, SensorsHtml, SensorNameHtml) {
 
     // TODO consider extracting all such usages to a shared ZeroClipboard wrapper?
-    ZeroClipboard.config({ moviePath: '//cdnjs.cloudflare.com/ajax/libs/zeroclipboard/1.3.1/ZeroClipboard.swf' });
+    ZeroClipboard.config({ moviePath: '/assets/img/zeroclipboard/ZeroClipboard.swf' });
     
     var sensorHtml = _.template(SensorsHtml),
         sensorNameHtml = _.template(SensorNameHtml);


### PR DESCRIPTION
fixes issues in some recent browser (eg latest chrome on latest os x)
where the flash "movie" won't load unless it is local.
the error it gives is a generic "uncaught exception" in
ZeroClipboard activate -> flashState.bridge.setSize.
curiously it still works fine in some browsers (firefox) and
older chrome was also fine but I'm guessing
security modes are being tightened in browsers.

none of the other recommended settings for fixing this seem to work:
* trustedDomains
* trustedOrigin
* allowScriptAccess
* and even the flash config in the browser

it's just a small movie however so should be low impact (smaller than most of our images).
put in img path to simplify access.

also, zeroclipboard is updated from 1.3.1 to 1.3.5 (latest stable 1.x branch).
(2.x branch looks like it might be a bigger api change although some fixes in this area are reported.)

this does not include the ZeroClipboard.swf binary but it will download it as is
normal practise for binary dependencies.  slightly unusually this uses maven to download it explicitly.