### PR TITLE
Allow relocation of Brooklyn REST API

### DIFF
--- a/src/main/webapp/assets/js/config.js
+++ b/src/main/webapp/assets/js/config.js
@@ -100,3 +100,17 @@ require([
 ], function (Router) {
     new Router().startBrooklynGui();
 });
+
+/*
+ * Prepend a base URL to REST API calls
+ */
+$.ajaxSetup({
+    beforeSend: function(jqXHR, settings) {
+//        var baseURL = "/api/brooklyn/";
+        var baseURL = "";
+
+        if (baseURL && settings.url.startsWith("/v1")) {
+            settings.url = (baseURL + settings.url).replace("//", "/");
+        }
+    }
+});


### PR DESCRIPTION
This PR follows the proposal on the mailing list about allowing the REST API to be relocated relative to brooklyn's web UI.

For now the function is not changed, but this allows administrators to deploy Brooklyn's REST API and its UI indepentent of each other's base URLs.