### PR TITLE
Ui fixes

### DIFF
--- a/src/main/webapp/assets/css/codemirror-brooklyn.css
+++ b/src/main/webapp/assets/css/codemirror-brooklyn.css
@@ -19,11 +19,15 @@
 
 /* overrides for brooklyn */
 
+.composer-editor {
+  height: calc(100vh - 290px);
+}
+
 .CodeMirror {
   height: auto;
 }
 .CodeMirror-scroll {
-  min-height: 480px;
+  min-height: calc(100vh - 285px);
 }
 .CodeMirror .CodeMirror-gutter.CodeMirror-linenumbers {
 }

--- a/src/main/webapp/assets/js/model/app-tree.js
+++ b/src/main/webapp/assets/js/model/app-tree.js
@@ -70,6 +70,7 @@ define([
             return entities;
         },
 
+        // returns true if the included entities ahs changed as a result
         includeEntities: function(entities) {
             // accepts id as string or object with id field
             var oldLength = this.includedEntities.length;

--- a/src/main/webapp/assets/js/router.js
+++ b/src/main/webapp/assets/js/router.js
@@ -197,10 +197,12 @@ define([
             this.appTree.fetch({success:function () {
                 var appExplorer = new ExplorerView({
                     collection:that.appTree,
-                    appRouter:that
-                })
+                    appRouter:that,
+                    initialTrail:trail
+                });
                 that.showView("#application-content", appExplorer)
                 if (trail !== undefined) appExplorer.show(trail)
+                else appExplorer.showDefaultSelection();
             }})
         },
         catalogPage: function (catalogItemKind, id) {

--- a/src/main/webapp/assets/js/view/application-explorer.js
+++ b/src/main/webapp/assets/js/view/application-explorer.js
@@ -87,7 +87,10 @@ define([
                 }
                 this.preselectTab(tab, tabDetails);
             }
-            this.treeView.selectEntity(entityId)
+            if (!this.treeView.selectEntity(entityId)) {
+                // needs a load
+                this.displayEntityId(entityId);
+            }
         },
         createApplication:function () {
             var that = this;
@@ -163,6 +166,10 @@ define([
                 return that.displayEntityNotFound(id);
             };
             if (appName === undefined) {
+                var $treebox = that.treeView.getTreebox(id);
+                appName = $treebox.children(".entity_tree_node_wrapper").children(".entity_tree_node").data("app-id");
+            }
+            if (appName === undefined) {
                 if (!afterLoad) {
                     // try a reload if given an ID we don't recognise
                     this.collection.includeEntities([id]);
@@ -184,6 +191,8 @@ define([
 
             app.url = "/v1/applications/" + appName;
             entitySummary.url = "/v1/applications/" + appName + "/entities/" + id;
+            if (id !== this.treeView.selectedEntityId)
+                this.treeView.selectEntity(id);
 
             // in case the server response time is low, fade out while it refreshes
             // (since we can't show updated details until we've retrieved app + entity details)

--- a/src/main/webapp/assets/js/view/entity-details.js
+++ b/src/main/webapp/assets/js/view/entity-details.js
@@ -107,11 +107,12 @@ define([
                     $(a).attr('href',entityHref+"/"+$(a).attr("data-target").slice(1));
                 });
             } else {
-                log("could not find entity href for tab");
+                // entity not available yet -- should be soon
+//                log("could not find entity href for tab");
             }
             if (this.options.preselectTab) {
                 var tabLink = this.$('a[data-target="#'+this.options.preselectTab+'"]');
-                var showFn = function() { tabLink.tab('show'); };
+                var showFn = function() { tabLink.tab('show', { duration: 0 }); };
                 if (optionalParent) showFn();
                 else _.defer(showFn);
             }
@@ -126,6 +127,9 @@ define([
             event.preventDefault();
             
             var tabName = $(event.currentTarget).attr("data-target").slice(1);
+            this.options.preselectTab = tabName;
+            this.options.preselectTabDetails = null;
+            
             var route = this.getTab(tabName);
             if (route) {
                 if (route[0]=='#') route = route.substring(1);


### PR DESCRIPTION
fixes several minor irritants in the ui

* ui auto-refresh bug: brooklyn-233, dynamic additions are not shown
* ui app-tree reload bug - selected entity hidden if you reload when non-root entity selected
* ui back button bug - tree view hid if you hit back button
* ui activities bug - stale data shown switching tabs and entities and going in to sub-tasks
* composer scrolling bug - the editor would hide the cursor if you do pg-down then pg-up on a large yaml
* composer autocomplete - now completes `location` after `services:` block, and filters unnecessary root proposals
