### PR TITLE
Move jQuery code inside a closure managed by require

### DIFF
--- a/src/main/webapp/assets/js/config.js
+++ b/src/main/webapp/assets/js/config.js
@@ -103,16 +103,3 @@ require([
     new Router().startBrooklynGui();
 });
 
-/*
- * Prepend a base URL to REST API calls
- */
-$.ajaxSetup({
-    beforeSend: function(jqXHR, settings) {
-//        var baseURL = "/api/brooklyn/";
-        var baseURL = "";
-
-        if (baseURL && settings.url.startsWith("/v1")) {
-            settings.url = (baseURL + settings.url).replace("//", "/");
-        }
-    }
-});

--- a/src/main/webapp/assets/js/router.js
+++ b/src/main/webapp/assets/js/router.js
@@ -253,5 +253,19 @@ define([
         }
     });
 
+    /*
+     * Prepend a base URL to REST API calls
+     */
+    $.ajaxSetup({
+        beforeSend: function(jqXHR, settings) {
+            // var baseURL = "/api/brooklyn/";
+            var baseURL = "";
+
+            if (baseURL && settings.url.startsWith("/v1")) {
+                settings.url = (baseURL + settings.url).replace("//", "/");
+            }
+        }
+    });
+
     return Router
 })


### PR DESCRIPTION
This is mainly to prevent javascript errors with jQuery not available when running Brooklyn from `BrooklynJavascriptGuiLauncher`