### PR TITLE
Update editor placeholder

### DIFF
--- a/src/main/webapp/assets/js/view/editor.js
+++ b/src/main/webapp/assets/js/view/editor.js
@@ -204,7 +204,8 @@ define([
                     hintOptions: {
                         completeSingle: false,
 //                        closeOnUnfocus: false,   // handy for debugging
-                    }
+                    },
+                    placeholder: "How to use it?\n- Enter blueprint yaml here\n- Drag & drop text files here\n\nPress Ctrl+Space for completion."
                 });
                 var oldYamlHint = CodeMirror.hint.yaml;
                 var that = this;

--- a/src/main/webapp/assets/tpl/editor/page.html
+++ b/src/main/webapp/assets/tpl/editor/page.html
@@ -57,7 +57,7 @@ under the License.
                         <div class="composer-toolbar">
                             <!-- the toolbar -->
                         </div>
-                        <textarea id="yaml_code" placeholder="# Enter blueprint yaml here. Press Ctrl+Space for completion." mode="yaml" class="code-textarea" style="height:760px; width:98%"></textarea>
+                        <textarea id="yaml_code" mode="yaml" class="code-textarea" style="height:760px; width:98%"></textarea>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The text now makes it clear that users can use drag & drop to add text files' content into the editor

![brooklyn js rest client](https://cloud.githubusercontent.com/assets/2082759/14321019/5cc569c2-fc0f-11e5-9205-3d819f90e002.png)