### PR TITLE
Hotfix: Skip the creation of the contains method within Array prototype

### DIFF
--- a/src/main/webapp/assets/js/view/location-wizard.js
+++ b/src/main/webapp/assets/js/view/location-wizard.js
@@ -541,7 +541,8 @@ define([
                                     return item.getIdentifierName();
                                 }),
                                 spec: ['localhost']
-                            }
+                            },
+                            loggerEnabled: false
                         });
                     }
                 });
@@ -702,7 +703,8 @@ define([
                         vmOptions: that.vmOptions,
                         osOptions: that.osOptions,
                         templateOptions: that.templateOptions
-                    }
+                    },
+                    loggerEnabled: false
                 });
             }, 100);
         },


### PR DESCRIPTION
This avoids breaking other parts of the UI