### PR TITLE
Show config values when jumping from App Wizard to YAML Preview

### DIFF
--- a/src/main/webapp/assets/js/view/application-add-wizard.js
+++ b/src/main/webapp/assets/js/view/application-add-wizard.js
@@ -303,6 +303,10 @@ define([
         },
         previewStep:function () {
             // no need for validation if going to composer
+
+            // When user jump to the YAML editor he also must have the config values that he set through the UI.
+            // The config is set implicitly when user clicks deploy and StepDeploy.validate is called.
+            this.currentView.model.spec.set("config", this.currentView.getConfigMap());
             if (this.currentStep==0) {
                 // from first step, composer should load yaml from the catalog item
                 if (this.currentView.selectedTemplate && this.currentView.selectedTemplate.id) {


### PR DESCRIPTION
I hope the title explains what it is fixing
![screenshot from 2016-05-24 14-57-36](https://cloud.githubusercontent.com/assets/1595054/15502988/e3d15284-21bf-11e6-9789-9ead6782906c.png)

I see that the `StepDeploy.validate` does more than validating the model.
Any suggestions for separating this logic or renaming the validate method to `fillConfigAndValidate`?
I do not understand how `ModalWizard`, `ModalWizard.StepCreate` and `ModalWizard.StepDeploy` are connected to each other.
@tbouron any comments?