### PR TITLE
request and set the csrf header protection added to brooklyn server

### DIFF
--- a/src/main/webapp/assets/js/model/server-extended-status.js
+++ b/src/main/webapp/assets/js/model/server-extended-status.js
@@ -22,6 +22,13 @@ define(["backbone", "brooklyn", "view/viewutils"], function (Backbone, Brooklyn,
         callbacks: [],
         loaded: false,
         url: "/v1/server/up/extended",
+        sync: function(method, collection, options){
+            options = options || {};
+            options.beforeSend = function (xhr) {
+                xhr.setRequestHeader('X-Csrf-Token-Required-For-Requests', 'write');
+            };
+            return Backbone.Model.prototype.sync.apply(this, arguments);
+        },
         onError: function(thiz,xhr,modelish) {
             log("ServerExtendedStatus: error contacting Brooklyn server");
             log(xhr);

--- a/src/main/webapp/assets/js/router.js
+++ b/src/main/webapp/assets/js/router.js
@@ -254,7 +254,7 @@ define([
     });
 
     /*
-     * Prepend a base URL to REST API calls
+     * Prepend a base URL to REST API calls, and add the CSRF token if present.
      */
     $.ajaxSetup({
         beforeSend: function(jqXHR, settings) {
@@ -263,6 +263,17 @@ define([
 
             if (baseURL && settings.url.startsWith("/v1")) {
                 settings.url = (baseURL + settings.url).replace("//", "/");
+            }
+            
+            // add CSRF token as header
+            var ca = document.cookie.split(';');
+            for (var i=0; i<ca.length; i++) {
+                var c = ca[i];
+                while (c.charAt(0)==' ') c = c.substring(1);
+                if (c.toLowerCase().indexOf('csrf-token') != -1) {
+                    var parts = c.split('=');
+                    jqXHR.setRequestHeader('X-'+parts[0], parts[1]);
+                }
             }
         }
     });


### PR DESCRIPTION
Minor tweaks to opt-in to CSRF protection in Brooklyn UI

NB requires https://github.com/apache/brooklyn-server/pull/430
(actually it will work fine without that, but it will be no-op)