### PR TITLE
[BROOKLYN-408] Add CSRF header on the swagger page

### DIFF
--- a/src/main/webapp/assets/html/swagger-ui.html
+++ b/src/main/webapp/assets/html/swagger-ui.html
@@ -50,6 +50,16 @@
                 supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
                 onComplete: function (swaggerApi, swaggerUi) {
                     log("Brooklyn swagger api doc loaded");
+                    // add CSRF token as header
+                    var ca = document.cookie.split(';');
+                    for (var i=0; i<ca.length; i++) {
+                        var c = ca[i];
+                        while (c.charAt(0)==' ') c = c.substring(1);
+                        if (c.toLowerCase().indexOf('csrf-token') != -1) {
+                            var parts = c.split('=');
+                            swaggerApi.clientAuthorizations.add('X-CSRF-TOKEN', new SwaggerClient.ApiKeyAuthorization('X-CSRF-TOKEN', parts[1], 'header'));
+                        }
+                    }
                 },
                 onFailure: function (data) {
                     log("Unable to Load SwaggerUI");


### PR DESCRIPTION
Since Brooklyn checks for CSRF header for every POST/PUT requests, the relevant methods didn't work anymore on the swagger UI page.

This fixes it by setting the header manually into the swagger configuration