### PR TITLE
Use the "itemType" to redirect the user to the right page after a catalog import

### DIFF
--- a/src/main/webapp/assets/js/view/editor.js
+++ b/src/main/webapp/assets/js/view/editor.js
@@ -335,7 +335,30 @@ define([
             if(succeeded){
                 log("Submit [succeeded] ... redirecting back to " + type);
                 if(type && type === 'catalog'){
-                    Backbone.history.navigate('v1/catalog', {trigger: true});
+                    var firstItem;
+                    var keys = _.keys(data);
+                    if (keys.length > 0) {
+                        firstItem = data[keys[0]];
+                    }
+                    var url = 'v1/catalog';
+                    if (firstItem) {
+                        switch (firstItem.itemType) {
+                            case 'template':
+                                url += '/applications';
+                                break;
+                            case 'entity':
+                                url += '/entities';
+                                break;
+                            case 'policy':
+                                url += '/policies';
+                                break;
+                            case 'location':
+                                url += '/locations';
+                                break;
+                        }
+                        url += '/' + firstItem.id;
+                    }
+                    Backbone.history.navigate(url, {trigger: true});
                 }else{
                     // no need to refresh apps (this.collection) because homePage route does that
                     Backbone.history.navigate('v1/home', {trigger: true});


### PR DESCRIPTION
As for today, when a user submit catalog item(s), the UI redirects to the catalog page, not to the newly created catalog item. This is due to the fact that the UI does not know what type of catalog item has been created and therefore cannot redirect the user properly.

This corrects this behaviours.

_Note: This requires https://github.com/apache/brooklyn-server/pull/567 **to be merged first**_