### PR TITLE
Add support for enricher catalog items

### DIFF
--- a/src/main/webapp/assets/js/view/catalog.js
+++ b/src/main/webapp/assets/js/view/catalog.js
@@ -448,6 +448,16 @@ define([
                     model: Entity.Model,
                     autoOpen: this.options.kind == "policies"
                 }),
+                "enrichers": new AccordionEntityView({
+                    // TODO needs parsing, and probably its own model
+                    // but cribbing "entity" works for now
+                    // (and not setting a model can cause errors intermittently)
+                    onItemSelected: _.partial(this.showCatalogItem, DetailsEntityHtml),
+                    name: "enrichers",
+                    singular: "enricher",
+                    model: Entity.Model,
+                    autoOpen: this.options.kind == "enrichers"
+                }),
                 "locations": new AccordionItemView({
                     name: "locations",
                     singular: "location",
@@ -511,6 +521,7 @@ define([
             this.loadAccordionItem("entities", id);
             this.loadAccordionItem("applications", id);
             this.loadAccordionItem("policies", id);
+            this.loadAccordionItem("enrichers", id);
             this.loadAccordionItem("locations", id);
         },
 

--- a/src/main/webapp/assets/js/view/editor.js
+++ b/src/main/webapp/assets/js/view/editor.js
@@ -352,6 +352,9 @@ define([
                             case 'policy':
                                 url += '/policies';
                                 break;
+                            case 'enricher':
+                                url += '/enrichers';
+                                break;
                             case 'location':
                                 url += '/locations';
                                 break;


### PR DESCRIPTION
**Requires https://github.com/apache/brooklyn-server/pull/638**

This adds a new accordion to display enrichers registered within the Brooklyn catalog

![screen shot 2017-04-14 at 20 12 07](https://cloud.githubusercontent.com/assets/2082759/25053577/f5586534-214f-11e7-8cd6-a57d5e11b826.png)

![screen shot 2017-04-14 at 20 12 12](https://cloud.githubusercontent.com/assets/2082759/25053580/f83b10e4-214f-11e7-8457-83c39138de09.png)
