### PR TITLE
if not using persistence and mgmt plane ID is null, UI can give erroneous error

### DIFF
--- a/src/main/webapp/assets/js/model/server-extended-status.js
+++ b/src/main/webapp/assets/js/model/server-extended-status.js
@@ -75,6 +75,7 @@ define(["backbone", "brooklyn", "view/viewutils"], function (Backbone, Brooklyn,
             ha = this.get("ha") || {};
             ownId = ha.ownId;
             if (!ownId) return null;
+            if (!ha.planeId) return true;
             return ha.masterId == ownId;
         },
         getMasterUri: function() {


### PR DESCRIPTION
fix it by accepting null plane as acceptable if server is otherwise healthy