### PR TITLE
Add local .m2 cache to list of exclusion for RAT plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,8 @@
                             Copy of swagger-ui from https://github.com/swagger-api/swagger-ui tag::v2.1.3
                         -->
                         <exclude>**/src/main/webapp/assets/swagger-ui/**</exclude>
+                        <!-- maven cache -->
+                        <exclude>**/.m2/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This is to fix the build (which uses Docker) on apache Jenkins: https://builds.apache.org/job/brooklyn-ui-master-docker/

It follows the same convention as this commit: https://github.com/apache/brooklyn-server/commit/b18d9699884faa3285f1fd256da1dc429f9096e0
This is necessary because `brooklyn-ui` parent pom is no `brooklyn-parent`