### PR TITLE
Add .m2 folder in the list of ignore folders for the RAT plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,8 @@
                         <!-- trivial config files, which contain comments so we can't insert the license header -->
                         <exclude>**/.babelrc</exclude>
                         <exclude>.mvn/jvm.config</exclude>
+                        <!-- maven cache -->
+                        <exclude>**/.m2/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
As `brooklyn-ui` doesn't use `brooklyn-parent`, we need to add the local maven cache for the Jenkins build