### PR TITLE
Customizable config widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ is to run `make` in the relevant module directory, with a Brooklyn REST server o
 For developers, the following links may be useful:
 
 * [Overview and architecture of the project](docs/overview.md)
-* [Creating a new UI module](tools/module-generator/README.md)
 * [Building individual module / Dev environment](ui-modules/home/README.md)
 * [Skinning the UI with custom themes](docs/skinning.md)
+* [Customizing and embedding the UI](docs/customizations.md)
 
 
 ## Troubleshooting

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -12,10 +12,12 @@ There are a number of points where UI default choices can be overridden:
   can extend existing Brooklyn items
 
 * Composer - Custom Config Widgets: special widgets to use for config keys can be specified in a registered type's
-  definition as a map tag, for example for the demo widget `suggestion-dropout` included we might have:
-      '{ ui-composer-hints: { config-widgets: [ { key: start.timeout, suggestion-values: [ 30s, 2m, 5m, 30m, 2h ],
-         widget: suggestion-dropdown, label-collapsed: fail after, label-expanded: Fail if not successful within } ] } }`;
-  widgets should be registered as angular directives using the standard naming conventions (e.g. suggestionDropdownDirective),
-  as done for that directive in app/index.js and app/index.less.
+  definition as a map tag, for example for the demo widget `suggestion-dropout` included we might have 
+      '{ ui-composer-hints: { config-widgets: [ { 
+         key: start.timeout, suggestion-values: [ 30s, 2m, 5m, 30m, 2h, { value: forever, description: 'No timeout' ],
+         widget: suggestion-dropdown, label-collapsed: fail after, label-expanded: Fail if not successful within } ] } }`
+  (as shown in the accompanying `vanillia-with-custom-widget.bom`);
+  widgets should be registered as angular directives using the standard Angular naming conventions 
+  (e.g. suggestionDropdownDirective), as done for that directive in app/index.js and app/index.less.
 
 

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -11,3 +11,11 @@ There are a number of points where UI default choices can be overridden:
   items for the palette can come from Brooklyn and/or other sources, with other sources converted to "virtual items" that
   can extend existing Brooklyn items
 
+* Composer - Custom Config Widgets: special widgets to use for config keys can be specified in a registered type's
+  definition as a map tag, for example for the demo widget `suggestion-dropout` included we might have:
+      '{ ui-composer-hints: { config-widgets: [ { key: start.timeout, suggestion-values: [ 30s, 2m, 5m, 30m, 2h ],
+         widget: suggestion-dropdown, label-collapsed: fail after, label-expanded: Fail if not successful within } ] } }`;
+  widgets should be registered as angular directives using the standard naming conventions (e.g. suggestionDropdownDirective),
+  as done for that directive in app/index.js and app/index.less.
+
+

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -1,0 +1,13 @@
+
+The UI is designed so modules can be used individually, or added as library modules in the usual NodeJS manner 
+and widgets cherry-picked as needed.
+
+There are a number of points where UI default choices can be overridden:
+
+* Actions on Composer: by changing the config value for `'actionServiceProvider'` in `ui-modules/blueprint-composer/app/index.js`,
+  a different set of actions can be displayed on the composer screen
+
+* Composer - Virtual palette items and alternate catalog endpoints:  by registering a different `blueprintServiceProvider`
+  items for the palette can come from Brooklyn and/or other sources, with other sources converted to "virtual items" that
+  can extend existing Brooklyn items
+

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -20,4 +20,21 @@ There are a number of points where UI default choices can be overridden:
   widgets should be registered as angular directives using the standard Angular naming conventions 
   (e.g. suggestionDropdownDirective), as done for that directive in app/index.js and app/index.less.
 
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
 
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->

--- a/docs/vanilla-with-custom-widget.bom
+++ b/docs/vanilla-with-custom-widget.bom
@@ -1,0 +1,25 @@
+brooklyn.catalog:
+  id: vanilla-with-custom-widget
+  version: 1.0.0-SNAPSHOT
+  iconUrl: https://cdn.shopify.com/s/files/1/0709/1933/products/valilla_flower_1024x1024.png?v=1479432384
+  itemType: entity
+  tags:
+  - ui-composer-hints:
+      config-widgets:
+      - key: start.timeout
+        widget: suggestion-dropdown
+        suggestion-values:
+        - value: 30s
+          description: 30 seconds
+        - value: 2m
+          description: 2 minutes
+        - 5m
+        - 30m
+        - value: 2h
+          description: 2 hours
+        - value: forever
+          description: No timeout
+        label-collapsed: fail after
+        label-expanded: Fail if not successful within
+  item:
+    type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess

--- a/docs/vanilla-with-custom-widget.bom
+++ b/docs/vanilla-with-custom-widget.bom
@@ -1,3 +1,21 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 brooklyn.catalog:
   id: vanilla-with-custom-widget
   version: 1.0.0-SNAPSHOT

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
@@ -1,0 +1,48 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<div class="custom-config-widget suggestion-dropdown config-flex-row">
+    <label class="control-label" for="{{item.name}}">
+        <span class="label-spec-configuration">{{item.label || item.name}}</span>
+        <span class="info-spec-configuration">
+            <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
+                popover-title="{{item.label || item.name}}"
+                uib-popover-template="'ConfigInfoTemplate.html'"
+                popover-class="spec-editor-popover" popover-placement="top-left" popover-append-to-body="true"></i>
+            </span>
+    </label>
+
+    <span class="label-rhs-buttons">
+        <span class="spacer"> </span>
+        <span class="custom-widget-enable-button custom-widget-active">
+            <i class="fa fa-fw fa-sun-o" ng-click="toggleCustomConfigWidgetMode(item, 'disabled')" aria-hidden="true" title="{{getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]"></i>
+            <span class="sr-only">{{getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]</span>
+        </span>
+    </span>
+
+    <div class="control-value" ng-class="{ 'inline-control': item.widgetMode==='boolean', 'unset': !defined(config[item.name]), 'has-default': defined(item.defaultValue) && item.defaultValue!=null }">
+        <div class="hide-when-collapsed">
+            <a ng-click="test()">Extra information</a>
+        </div>
+        <div>
+            <span class="hide-when-expanded">Custom widget: </span>
+            {{ config[item.name] }}
+        </div>
+    </div>
+
+</div>

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
@@ -36,13 +36,32 @@
     </span>
 
     <div class="control-value" ng-class="{ 'inline-control': item.widgetMode==='boolean', 'unset': !defined(config[item.name]), 'has-default': defined(item.defaultValue) && item.defaultValue!=null }">
-        <div class="hide-when-collapsed">
+        <div class="hide-when-collapsed extra-label" ng-if="params['label-expanded']">
             {{ params['label-expanded'] || "" }}
         </div>
-        <div>
-            <span class="hide-when-expanded">{{ params['label-collapsed'] || "" }}</span>
-            {{ config[item.name] }}
+        <div class="config-flex-row">
+            <span class="hide-when-expanded inline-label extra-label" ng-if="params['label-collapsed']">{{ params['label-collapsed'] || "" }}</span>
+            <div class="input-group">
+                <textarea ng-model="config[item.name]" class="form-control" name="{{item.name}}" id="{{item.name}}" auto-grow
+                          placeholder="{{defined(config[item.name]) ? null : item.defaultValue=='' || item.defaultValue==null ? '(empty)' : item.defaultValue}}"
+                          ng-focus="recordFocus(item)" on-enter="advanceOutToFormGroupInPanel"
+                          uib-typeahead="suggestion.value for suggestion in getSuggestions() | filter:{value:$viewValue}"
+                          typeahead-min-length=0
+                          typeahead-template-url="SuggestionTemplate.html"></textarea>
+                <span class="input-group-btn dsl-wizard-button" ng-if="isDslWizardButtonAllowed(item.name)">
+                    <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name})" class="btn btn-default" title="Open in DSL editor"><i class="fa fa-bolt"></i></a>
+                </span>
+            </div>
         </div>
     </div>
 
 </div>
+
+<!--TYPEAHEAD TEMPLATE :: START-->
+<script type="text/ng-template" id="SuggestionTemplate.html">
+    <div class="dropdown-item">
+        <span class="dropdown-item-value" ng-bind-html="match.model.value | uibTypeaheadHighlight:query"></span>
+        <p class="dropdown-item-description" ng-if="match.model.description">{{ match.model.description }}</p>
+    </div>
+</script>
+<!--TYPEAHEAD TEMPLATE :: END-->

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
@@ -30,17 +30,17 @@
     <span class="label-rhs-buttons">
         <span class="spacer"> </span>
         <span class="custom-widget-enable-button custom-widget-active">
-            <i class="fa fa-fw fa-sun-o" ng-click="toggleCustomConfigWidgetMode(item, 'disabled')" aria-hidden="true" title="{{getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]"></i>
+            <i class="fa fa-fw fa-sun-o" ng-click="toggleCustomConfigWidgetMode(item, false)" aria-hidden="true" title="{{getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]"></i>
             <span class="sr-only">{{getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]</span>
         </span>
     </span>
 
     <div class="control-value" ng-class="{ 'inline-control': item.widgetMode==='boolean', 'unset': !defined(config[item.name]), 'has-default': defined(item.defaultValue) && item.defaultValue!=null }">
         <div class="hide-when-collapsed">
-            <a ng-click="test()">Extra information</a>
+            {{ params['label-expanded'] || "" }}
         </div>
         <div>
-            <span class="hide-when-expanded">Custom widget: </span>
+            <span class="hide-when-expanded">{{ params['label-collapsed'] || "" }}</span>
             {{ config[item.name] }}
         </div>
     </div>

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
@@ -40,7 +40,20 @@ export function suggestionDropdownDirective($rootScope) {
 
     function link(scope) {
         scope.$parent.copyScopeForCustomConfigWidget(scope);
-        console.log("params for widget for "+scope.item.name, scope.params);
+        
+        scope.getSuggestions = () => {
+            var result = [];
+            if (scope.params['suggestion-values']) {
+                scope.params['suggestion-values'].forEach( (v) => {
+                    if (v["value"]) {
+                        result.push(v);
+                    } else {
+                        result.push({value: v});
+                    }
+                });
+                return result;
+            }
+        };
     }
     
 }

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
@@ -40,7 +40,6 @@ export function suggestionDropdownDirective($rootScope) {
 
     function link(scope) {
         scope.$parent.copyScopeForCustomConfigWidget(scope);
-        
         scope.getSuggestions = () => {
             var result = [];
             if (scope.params['suggestion-values']) {

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
@@ -31,7 +31,8 @@ export function suggestionDropdownDirective($rootScope) {
     return {
         restrict: 'E',
         scope: {
-            item: '='
+            item: '=',
+            params: '=',
         },
         template: template,
         link: link,
@@ -39,6 +40,7 @@ export function suggestionDropdownDirective($rootScope) {
 
     function link(scope) {
         scope.$parent.copyScopeForCustomConfigWidget(scope);
+        console.log("params for widget for "+scope.item.name, scope.params);
     }
     
 }

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ 
+import angular from 'angular';
+import template from './suggestion-dropdown.html';
+
+const MODULE_NAME = 'brooklyn.components.custom-config-widget.suggestion-dropdown';
+
+angular.module(MODULE_NAME, [])
+    .directive('suggestionDropdown', ['$rootScope', suggestionDropdownDirective]);
+
+export default MODULE_NAME;
+
+export function suggestionDropdownDirective($rootScope) {
+    return {
+        restrict: 'E',
+        scope: {
+            item: '='
+        },
+        template: template,
+        link: link,
+    };
+
+    function link(scope) {
+        scope.$parent.copyScopeForCustomConfigWidget(scope);
+    }
+    
+}

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.less
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.less
@@ -41,24 +41,28 @@ suggestion-dropdown {
         // hide the dropdown menu when collapsed
         display: none;
     }
+    
     .dropdown-menu li a {
         // quite a lot of padding in normal dropdown, in the ul and in the a
         padding: 0;
     }
-    
     .dropdown-item {
         display: flex;
         flex-flow: row wrap;
+        width: 100%;
     }
     .dropdown-item-value {
+        flex: 1 0 auto;
     }
     .dropdown-item-description {
-        flex: 1 1 auto;
+        flex: 10 1 auto;
         text-align: right;
         font-style: italic;
         font-size: 80%;
-        flex: 1 1 auto;
         margin-bottom: 0;
-        margin-left: 6px;
+        margin-left: 12px;
+        max-width: 70%;
+        margin-top: 2px;
+        line-height: 18px;
     }
 }

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.less
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.less
@@ -24,7 +24,41 @@ suggestion-dropdown {
     .control-value {
         // for widgets that are text, this aligns it with the label when collapsed and gives nice spacing when expanded.
         // (for widgets that are dropdowns etc this should be omitted)
-        padding-top: 2px;
+//        padding-top: 2px;
     }
-
+    .extra-label {
+        // this seems to work best here (instead of padding above) when combining a label with a textarea control 
+        padding-top: 4px;
+    }
+    .inline-label {
+        margin-right: 5px;
+        white-space: nowrap;
+    }
+    spec-editor .spec-configuration .form-group & .control-value .config-flex-row {
+        flex-flow: nowrap;
+    }
+    .form-group:not(:focus-within):not(:focus) & .control-value .dropdown-menu {
+        // hide the dropdown menu when collapsed
+        display: none;
+    }
+    .dropdown-menu li a {
+        // quite a lot of padding in normal dropdown, in the ul and in the a
+        padding: 0;
+    }
+    
+    .dropdown-item {
+        display: flex;
+        flex-flow: row wrap;
+    }
+    .dropdown-item-value {
+    }
+    .dropdown-item-description {
+        flex: 1 1 auto;
+        text-align: right;
+        font-style: italic;
+        font-size: 80%;
+        flex: 1 1 auto;
+        margin-bottom: 0;
+        margin-left: 6px;
+    }
 }

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.less
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.less
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ 
+suggestion-dropdown {
+
+    width: 100%;
+    
+    .control-value {
+        // for widgets that are text, this aligns it with the label when collapsed and gives nice spacing when expanded.
+        // (for widgets that are dropdowns etc this should be omitted)
+        padding-top: 2px;
+    }
+
+}

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -499,9 +499,25 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         }));
         entity.miscData.set('sensors', data.sensors || []);
         entity.miscData.set('traits', data.supertypes || []);
+        entity.miscData.set('tags', data.tags || []);
+        var uiHints = {};
+        data.tags.forEach( (t) => { 
+            mergeAppendingLists(uiHints, t['ui-composer-hints']);
+        });
+        entity.miscData.set('ui-composer-hints', uiHints);
         entity.miscData.set('virtual', data.virtual || null);
         addUnlistedConfigKeysDefinitions(entity);
         return entity;
+    }
+    function mergeAppendingLists(dst, src) {
+        for (let p in src) {
+            if (Array.isArray(dst[p]) || Array.isArray(src[p])) {
+                dst[p] = [].concat(dst[p] || [], src[p]);
+            } else {
+                dst[p] = Object.assign({}, dst[p], src[p]);
+            }
+        }
+        return dst;
     }
 
     function populateEntityFromApiError(entity) {

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -303,7 +303,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             scope.state.config.add.open = false;
             scope.state.config.focus = $item.name;
             if ($item.isHidden) {
-                scope.state.config.filter.values[ CONFIG_FILTERS[CONFIG_FILTERS.length - 1] ].id = true;
+                scope.state.config.filter.values.all = true;
             }
         };
         scope.recordFocus = ($item)=> {

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -106,10 +106,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 codeModeActive: {},
                 codeModeForced: {},
                 codeModeError: {},
-                customConfigWidgetMetadata: { 
-                    "defaultDisplayName": { enabled: true, widget: "known-widget-missing" }, 
-                    "download.url": { enabled: true, widget: "suggestion-dropdown" }, 
-                },
+                customConfigWidgetMetadata: {},
             },
             location: {
                 open: false
@@ -612,18 +609,13 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         }
 
         function loadCustomConfigWidgetMetadata(model) {
-            console.log("misc data", model.miscData, scope.model.miscData.get('ui-composer-hints'));
             var customConfigWidgets = (scope.model.miscData.get('ui-composer-hints') || {})['config-widgets'] || [];
-            console.log("customs", customConfigWidgets);
             customConfigWidgets.forEach( (wd) => {
-                console.log("looking at", wd);
                 var keys = wd.keys || [ wd.key ];
                 keys.forEach( (k) => {
-                    console.log("setting key", k);
                     scope.state.config.customConfigWidgetMetadata[k] = angular.extend({ enabled: true }, scope.state.config.customConfigWidgetMetadata[k], wd);
                 });
             });
-            console.log("custom config", scope.state.config.customConfigWidgetMetadata);
         }
         
         /* config state for each item is stored in multiple places:

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -338,7 +338,7 @@ spec-editor {
       }
     }
     .form-group {
-        &, .config-flex-row, .custom-widget-full {
+        &, .config-flex-row, .custom-config-widget {
             display: flex;
             flex-flow: row wrap;
             width: 100%;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -235,9 +235,6 @@ spec-editor {
     }
   }
 
-  .spec-configuration-add {
-    margin-bottom: 15px;
-  }
   .spec-configuration {
     & > div {
       margin-top: 30px;
@@ -771,6 +768,17 @@ spec-editor {
     padding: 0.5em;
     margin-top: -12px;
     margin-bottom: 24px;
+    .dropdown-menu li a {
+        // quite a lot of padding in normal dropdown, in the ul and in the a
+        padding: 0;
+    }
+    .dropdown-item {
+        .config-name {
+            font-family: courier;
+            font-size: 95%;
+            margin-right: 1ex;
+        }
+    }
 
     legend {
       color: @gray;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -272,11 +272,22 @@ spec-editor {
       margin-right: 0.5em;
       .remove-affordance();
     }
+    span.rhs-buttons-subspan {
+      display: flex;
+    }
     .json-config i {
         margin-top: 2px; //nudge down to make aligned
     }
-    .dsl-open-wizard-from-toolbar, .dsl-manual-override-editor, .json-config {
+    .dsl-open-wizard-from-toolbar, .dsl-manual-override-editor, .json-config, .custom-widget-enable-button {
         .toolbar-button-affordance()
+    }
+    .custom-widget-enable-button.custom-widget-active {
+        i {
+            color: @brand-primary;
+        }
+        &:hover i {
+            color: @gray-light;
+        }
     }
     .dsl-manual-override-editor.dsl-viewer-manual-override,
     .json-config.code-mode-active {
@@ -327,8 +338,11 @@ spec-editor {
       }
     }
     .form-group {
-        display: flex;
-        flex-flow: row wrap;
+        &, .config-flex-row, .custom-widget-full {
+            display: flex;
+            flex-flow: row wrap;
+            width: 100%;
+        }
         .control-label {
             flex: 0 0 auto;
             order: 10;
@@ -406,6 +420,9 @@ spec-editor {
             }
         }
         &:not(:focus-within):not(:focus) {
+            .hide-when-collapsed {
+                display: none;
+            }
             input {
                 // the RHS is square if DSL button hidden; simplest fix is to make LHS square too
                 border-radius: 0;
@@ -426,6 +443,9 @@ spec-editor {
         }
     }
     .form-group:focus, .form-group:focus-within {
+        .hide-when-expanded {
+            display: none;
+        }
         .control-value:not(.inline-control) {
             flex-basis: 100%;
         }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -79,13 +79,11 @@
     </fieldset>
 
     <fieldset uib-collapse="!state.config.add.open" class="spec-configuration-add">
-        <legend>Add config key</legend>
-
         <input auto-focus="state.config.add.open"
              type="text"
              autocomplete="off"
              ng-model="state.config.add.value"
-             placeholder="Add a new configuration key"
+             placeholder="Add a new configuration key or open existing"
              class="form-control"
              uib-typeahead="config.name for config in state.config.add.list | filter:{name:$viewValue}"
              typeahead-template-url="ConfigItemTemplate.html"
@@ -99,14 +97,12 @@
 
         <div ng-if="state.config.add.value.length > 0 && noResults" uib-dropdown uib-dropdown-toggle auto-close="disabled" is-open="true">
             <ul class="dropdown-menu">
-                <li><a ng-click="addConfigKey()">
-                    <div class="dropdown-item">
-                        <div class="details">
-                            <h4 class="dropdown-item-heading repo-name truncate">
-                                <span ng-bind-html="state.config.add.value | uibTypeaheadHighlight:state.config.add.value"></span>
-                            </h4>
-                            <p class="dropdown-item-subheading version truncate">Click to add the new config key</p>
-                        </div>
+                <!-- mimic real dropdown if nothing found -->
+                <li class="uib-typeahead-match"><a ng-click="addConfigKey()">
+                    <div class="dropdown-item" ng-init="item = match.model">
+                        <div class="dropdown-row">
+                        <span ng-bind-html="state.config.add.value | uibTypeaheadHighlight:query" class="config-name"></span>
+                        <i class="fa fa-fw fa-plus-square-o"></i>
                     </div>
                 </a></li>
             </ul>
@@ -455,14 +451,14 @@
 
 <!--TYPEAHEAD TEMPLATE :: START-->
 <script type="text/ng-template" id="ConfigItemTemplate.html">
-    <div class="dropdown-item">
-        <div class="details">
-            <h4 class="dropdown-item-heading repo-name truncate">
-                <span ng-bind-html="match.model.label | uibTypeaheadHighlight:query"></span>
-                <i class="fa fa-fw fa-asterisk" ng-if="match.model.constraints.required"></i>
-                <i class="fa fa-fw fa-eye-slash" ng-if="match.model.isHidden"></i>
-            </h4>
-            <p class="dropdown-item-subheading version truncate">{{ match.model.description }}</p>
+    <div class="dropdown-item" ng-init="item = match.model">
+        <div class="dropdown-row">
+            <span ng-bind-html="match.model.name | uibTypeaheadHighlight:query" class="config-name"></span>
+            <i class="fa fa-fw fa-asterisk" ng-if="match.model.constraints.required"></i>
+            <i class="fa fa-fw fa-eye-slash" ng-if="match.model.isHidden"></i>
+            <!-- previously showed just the label; now show just the name as that's what is inserted.
+                 ideally would show label and description as popover (reusing ConfigInfoTemplate), but due to bugs in popover 
+                 we can't easily get that to work. -->
         </div>
     </div>
 </script>

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -139,12 +139,12 @@
                         auto-focus-not-if-within="true"
                         ng-focus="recordFocus(item)"
                         on-enter="advanceControlInFormGroup">
-                  <div ng-if="getCustomConfigWidgetMode(item) === 'full'" class="custom-widget-full">
-                    <ng-include src="getCustomConfigWidgetTemplate(item)" class="custom-widget-full"/>
+                  <div ng-if="getCustomConfigWidgetMode(item) === 'enabled'" class="custom-config-widget">
+                    <ng-include src="getCustomConfigWidgetTemplate(item)" class="custom-config-widget"/>
                   </div>
                   
                   <!-- have to hide it; excluding it conditionally via if doesn't play nice with switch -->
-                  <div ng-show="getCustomConfigWidgetMode(item) !== 'full'" class="config-flex-row">
+                  <div ng-show="getCustomConfigWidgetMode(item) !== 'enabled'" class="config-flex-row">
                     <label class="control-label" for="{{item.name}}">
                         <span class="label-spec-configuration">{{item.label || item.name}}</span>
                         <span class="info-spec-configuration">

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -131,12 +131,20 @@
 
         <form name="formSpecConfig" novalidate class="lightweight">
             <div ng-repeat="item in (filteredItems = (model.miscData.get('config') | specEditorConfig:state.config.filter.values:model.config | filter:{name:state.config.search} | orderBy:+priority)) track by item.name ">
-                <div class="form-group" ng-class="{'has-error': (model.issues | filter:{ref: item.name}:true).length > 0, 'used': config[item.name] !== undefined}" ng-switch="getConfigWidgetMode(item)" tabindex="1"
+                <div class="form-group" ng-class="{'has-error': (model.issues | filter:{ref: item.name}:true).length > 0, 'used': config[item.name] !== undefined}" 
+                        ng-switch="getConfigWidgetMode(item)" 
+                        tabindex="1"
                         auto-focus="state.config.focus === item.name"
                         auto-focus-listen-to-window="true"
                         auto-focus-not-if-within="true"
                         ng-focus="recordFocus(item)"
                         on-enter="advanceControlInFormGroup">
+                  <div ng-if="getCustomConfigWidgetMode(item) === 'full'" class="custom-widget-full">
+                    <ng-include src="getCustomConfigWidgetTemplate(item)" class="custom-widget-full"/>
+                  </div>
+                  
+                  <!-- have to hide it; excluding it conditionally via if doesn't play nice with switch -->
+                  <div ng-show="getCustomConfigWidgetMode(item) !== 'full'" class="config-flex-row">
                     <label class="control-label" for="{{item.name}}">
                         <span class="label-spec-configuration">{{item.label || item.name}}</span>
                         <span class="info-spec-configuration">
@@ -149,11 +157,15 @@
                     
                     <span class="label-rhs-buttons">
                         <span class="spacer"> </span>
-                        <span class="json-config" ng-class="{'code-mode-active': state.config.codeModeActive[item.name], 'code-mode-forced': state.config.codeModeForced[item.name]}" ng-if="isCodeModeAvailable(item)">
-                            <i class="fa fa-fw fa-code" ng-click="codeModeClick(item)" aria-hidden="true" title="{{getJsonModeTitle(item.name)}}"></i>
-                            <span class="sr-only">{{getJsonModeTitle(item.name)}}</span>
+                        <span class="custom-widget-enable-button" ng-if="getCustomConfigWidgetMode(item) !== null">
+                            <i class="fa fa-fw fa-sun-o" ng-click="toggleCustomConfigWidgetMode(item)" aria-hidden="true" title="{{getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]"></i>
+                            <span class="sr-only">{{getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]</span>
                         </span>
-                        <span ng-if="isDsl(item.name)">
+                        <span class="json-config" ng-class="{'code-mode-active': state.config.codeModeActive[item.name], 'code-mode-forced': state.config.codeModeForced[item.name]}" ng-if="isCodeModeAvailable(item)">
+                            <i class="fa fa-fw fa-code" ng-click="codeModeClick(item)" aria-hidden="true" title="{{getJsonModeTitle(item.name)}} [{{item.name}}]"></i>
+                            <span class="sr-only">{{getJsonModeTitle(item.name)}} [{{item.name}}]</span>
+                        </span>
+                        <span ng-if="isDsl(item.name)" class="rhs-buttons-subspan">
                             <span class="dsl-open-wizard-from-toolbar" ng-if="!state.config.dslViewerManualOverride[item.name]">
                                 <i class="fa fa-fw fa-bolt" ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name})" aria-hidden="true" title="Open in DSL editor [{{item.name}}]"></i>
                                 <span class="sr-only">Open in DSL editor [{{item.name}}]</span>
@@ -309,6 +321,8 @@
                     </div>
                     
                     <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
+                  </div>
+
                 </div>
             </div>
         </form>

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -48,6 +48,7 @@ import {
     catalogSelectorSortFilter
 } from "components/catalog-selector/catalog-selector.directive";
 import customActionDirective from "./components/custom-action/custom-action.directive";
+import customConfigSuggestionDropdown from "components/custom-config-widget/suggestion-dropdown";
 import {onErrorDirective} from "components/catalog-selector/on-error.directive";
 import {breadcrumbsDirective} from "components/breacrumbs/breadcrumbs.directive";
 import {recursionHelperFactory} from "components/factories/recursion-helper.factory";
@@ -71,7 +72,10 @@ import {graphicalEditDslState, dslParamLabelFilter} from "views/main/graphical/e
 import bottomSheet from "brooklyn-ui-utils/bottom-sheet/bottom-sheet";
 import stackViewer from 'angular-java-stack-viewer';
 
-angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 'ui.router.state.events', brCore, brServerStatus, brAutoFocus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brYamlEditor, brUtils, brSpecEditor, brooklynCatalogSaver, brooklynApi, bottomSheet, stackViewer, brDragndrop, customActionDirective, paletteApiProvider])
+angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 'ui.router.state.events', brCore, 
+        brServerStatus, brAutoFocus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, 
+        brYamlEditor, brUtils, brSpecEditor, brooklynCatalogSaver, brooklynApi, bottomSheet, stackViewer, brDragndrop, 
+        customActionDirective, customConfigSuggestionDropdown, paletteApiProvider])
     .directive('designer', ['$log', '$state', '$q', 'iconGenerator', 'catalogApi', 'blueprintService', 'brSnackbar', 'paletteDragAndDropService', designerDirective])
     .directive('onError', onErrorDirective)
     .directive('catalogSelector', catalogSelectorDirective)

--- a/ui-modules/blueprint-composer/app/index.less
+++ b/ui-modules/blueprint-composer/app/index.less
@@ -31,6 +31,7 @@
 @import "components/spec-editor/spec-editor";
 @import "components/catalog-selector/catalog-selector";
 @import "components/breacrumbs/breadcrumbs";
+@import "components/custom-config-widget/suggestion-dropdown";
 @import "components/blueprint-data-manager/blueprint-data-manager.style.less";
 @import "components/catalog-saver/catalog-saver.less";
 @import "components/dsl-editor/dsl-editor";


### PR DESCRIPTION
Adds the ability to define custom widgets for config, and supplies one such with an example as shown in `docs/vanilla-with-custom-widget.bom`.

<img width="465" alt="screen shot 2018-08-07 at 16 37 58" src="https://user-images.githubusercontent.com/496540/43786331-48a09010-9a60-11e8-8203-ae8aa0adac76.png">
