### PR TITLE
Allow UI modules to actively resolve conflicts

### DIFF
--- a/modularity-server/README.md
+++ b/modularity-server/README.md
@@ -9,6 +9,29 @@ This folder contains projects which help working with and extending the UI:
 
 Note that UI modules themselves are in `../ui-modules`.
 
+# UI Module Config
+
+A Brooklyn UI module is a WAR being installed which includes a file `ui-module/config.yaml`
+defining at minimum:
+
+* a `name` (to be displayed in the UI)
+* a `slug` (used internally for reference; usually this is set to be `${project.artifactId}` and substituted during the build)
+* an `icon` CSS class set, usually Font Awesome based (e.g. `fa-home`).  
+
+Optionally it can include:
+
+* a list of `type` tokens for arbitrary use (currently `home-ui-module` is used to indicate a module should
+  show up on the home page, and `library-ui-module` to indicate it should be excluded from the menu)
+* `actions` (not used currently, see code to understand)
+* `stopExisting` (boolean, whether to stop lower-numbered bundles listening on the same
+  context-path declared in `web.xml`, defaulting to `true`)
+* `supersedesBundles` (a list of `bundle-regex:version-regex` of bundles that should be stopped 
+  when this UI module is installed; this is used for downstream projects that may override UI modules 
+  and wish to ensure their modules are used without relying on bundle install order (but often bundle install order is sufficient))
+
+The Karaf command `web:list` is helpful in determining which module is actually active
+when there are conflicts for a given context path.
+
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/modularity-server/README.md
+++ b/modularity-server/README.md
@@ -25,7 +25,7 @@ Optionally it can include:
 * `actions` (not used currently, see code to understand)
 * `stopExisting` (boolean, whether to stop lower-numbered bundles listening on the same
   context-path declared in `web.xml`, defaulting to `true`)
-* `supersedesBundles` (a list of `bundle-regex:version-regex` of bundles that should be stopped 
+* `supersedes` (a list of `bundle-regex:version-regex` of bundles that should be stopped 
   when this UI module is installed; this is used for downstream projects that may override UI modules 
   and wish to ensure their modules are used without relying on bundle install order (but often bundle install order is sufficient))
 

--- a/modularity-server/external-modules/src/main/java/org/apache/brooklyn/ui/modularity/ExternalUiModule.java
+++ b/modularity-server/external-modules/src/main/java/org/apache/brooklyn/ui/modularity/ExternalUiModule.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.brooklyn.ui.modularity.module.api.UiModule;
+import org.apache.brooklyn.ui.modularity.module.api.UiModuleAction;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.osgi.service.component.annotations.Activate;
@@ -35,9 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
-
-import org.apache.brooklyn.ui.modularity.module.api.UiModule;
-import org.apache.brooklyn.ui.modularity.module.api.UiModuleAction;
 
 @Component(
         name = ExternalUiModule.PID,
@@ -59,12 +58,16 @@ public class ExternalUiModule implements UiModule {
     private final String KEY_ICON = "icon";
     private final String KEY_TYPES = "types";
     private final String[] REQUIRED_KEYS = new String[] {KEY_ID, KEY_NAME, KEY_URL, KEY_ICON};
+    private final String KEY_SUPERSEDES = "supersedes";
+    private final String KEY_STOP_EXISTING = "stopExisting";
 
     private String id;
     private String name;
     private String icon;
     private String url;
     private Set<String> types;
+    private Set<String> supersedes;
+    private boolean stopExisting;
 
     @Activate
     public void activate(final Map<String, String> properties) {
@@ -94,12 +97,20 @@ public class ExternalUiModule implements UiModule {
         this.name = properties.get(KEY_NAME);
         this.icon = properties.get(KEY_ICON);
         this.url = properties.get(KEY_URL);
+        
         this.types = MutableSet.of(MODULE_TYPE);
-
         final String userTypes = properties.get(KEY_TYPES);
         if (userTypes != null) {
             this.types.addAll(Arrays.asList(userTypes.split(",")));
         }
+        
+        this.supersedes = MutableSet.of(MODULE_TYPE);
+        final String userSupersedes = properties.get(KEY_SUPERSEDES);
+        if (userSupersedes != null) {
+            this.supersedes.addAll(Arrays.asList(userSupersedes.split(",")));
+        }
+
+        this.stopExisting = properties.get(KEY_STOP_EXISTING)!=null ? Boolean.parseBoolean(properties.get(KEY_STOP_EXISTING)) : true;
     }
 
     @Override
@@ -127,6 +138,16 @@ public class ExternalUiModule implements UiModule {
         return this.types;
     }
 
+    @Override
+    public Set<String> getSupersedesBundles() {
+        return supersedes;
+    }
+    
+    @Override
+    public boolean getStopExisting() {
+        return stopExisting;
+    }
+    
     @Override
     public String getPath() {
         return this.url;

--- a/modularity-server/module-api/pom.xml
+++ b/modularity-server/module-api/pom.xml
@@ -63,6 +63,18 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.web</groupId>
+            <artifactId>org.apache.karaf.web.core</artifactId>
+            <version>${karaf.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.web</groupId>
+            <artifactId>pax-web-spi</artifactId>
+            <version>6.0.6</version>  <!-- as it's provided we just need compile support; runtime is pulled in by karaf -->
+            <scope>provided</scope>
+        </dependency>
 
         <!--TEST SCOPE-->
         <dependency>

--- a/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModule.java
+++ b/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModule.java
@@ -48,14 +48,25 @@ public interface UiModule {
      * @return The module types eg single-page-app, external-ui
      */
     Set<String> getTypes();
+    
+    /**
+     * @return List of "bundle-regex" or "bundle-regex:version-regex" of bundles that should be stopped when this is installed.
+     * Useful if supplying a bundle to replace other bundles.
+     */
+    Set<String> getSupersedesBundles();
 
+    /**
+     * @return Whether to web-stop any bundles listening on the same endpoint. 
+     */
+    boolean getStopExisting();
+    
     /**
      * @return The module path
      */
     String getPath();
 
     /**
-     * @return Registed module actions
+     * @return Registered module actions
      */
     List<UiModuleAction> getActions();
 }

--- a/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModuleListener.java
+++ b/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModuleListener.java
@@ -19,25 +19,32 @@
 package org.apache.brooklyn.ui.modularity.module.api;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import org.apache.brooklyn.ui.modularity.module.api.internal.UiModuleImpl;
+import org.apache.karaf.web.WebBundle;
+import org.apache.karaf.web.WebContainerService;
+import org.ops4j.pax.web.service.spi.WebEvent;
+import org.ops4j.pax.web.service.spi.WebListener;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
-
-import org.apache.brooklyn.ui.modularity.module.api.internal.UiModuleImpl;
 
 /** Invoked by modules in their web.xml to create and register the {@link UiModule} service for that UI module. */
 public class UiModuleListener implements ServletContextListener {
@@ -47,6 +54,7 @@ public class UiModuleListener implements ServletContextListener {
     public static final String CONFIG_PATH = "/WEB-INF/classes/ui-module/config.yaml";
 
     private ServiceRegistration<UiModule> registration;
+    private AtomicReference<WebListener> listener = new AtomicReference<>();
 
     public UiModuleListener() {
     }
@@ -54,13 +62,15 @@ public class UiModuleListener implements ServletContextListener {
     public void contextInitialized(ServletContextEvent servletContextEvent) {
         final UiModule uiModule = createUiModule(servletContextEvent.getServletContext());
         Object moduleBundle = servletContextEvent.getServletContext().getAttribute("osgi-bundlecontext");
+        final Bundle bundle = moduleBundle instanceof BundleContext ? ((BundleContext)moduleBundle).getBundle() : FrameworkUtil.getBundle(this.getClass());
+        
+        initWebListener(bundle);
         
         // register service against the bundle where it came from if possible (it always is, from what I've seen)
         // this prevents errors if this.getClass()'s bundle is not yet active and avoids needing to delay
         // (it also means service would be unregistered on that bundle destroy without listening for servlet context
         // destroy but servlet context destroy is useful for symmetry with this and in case it is destroyed without 
         // destroying the bundle; also we were already doing it)
-        final Bundle bundle = moduleBundle instanceof BundleContext ? ((BundleContext)moduleBundle).getBundle() : FrameworkUtil.getBundle(this.getClass());
         
         try {
             if (bundle.getState() != Bundle.ACTIVE) {
@@ -69,13 +79,145 @@ public class UiModuleListener implements ServletContextListener {
                     bundle.getSymbolicName(), uiModule.getName(), bundle.getState(), TIMEOUT);
                 blockUntilBundleStarted(bundle, TIMEOUT);
             }
-            LOG.info("Registering new Brooklyn UI module [{}] to [{}] (bundle [{}:{}])", uiModule.getName(), uiModule.getPath(), bundle.getSymbolicName(), bundle.getVersion());
+            LOG.info("Registering new Brooklyn UI module {}:{} [{}] called '{}' on context-path '{}'", 
+                bundle.getSymbolicName(), bundle.getVersion(), bundle.getVersion(), uiModule.getName(), uiModule.getPath() );
             registration = bundle.getBundleContext().registerService(UiModule.class, uiModule, EMPTY_DICTIONARY);
+            LOG.trace("ServletContextListener on initializing UI module "+bundle.getSymbolicName()+" ["+bundle.getBundleId()+"] "
+                + "to "+uiModule.getPath()+", checking whether any bundles need stopping");
+            stopAnyExistingOrSuperseded(uiModule, bundle);
         } catch (Exception e) {
             LOG.error("Failed registration of Brooklyn UI module [" + uiModule.getName() + "] to [" + uiModule.getPath() + "]: "+e, e);
         }
     }
+
+    private void initWebListener(Bundle bundle) {
+        if (listener.compareAndSet(null, new UiModuleWebListener())) {
+            bundle.getBundleContext().registerService(WebListener.class, listener.get(), null);
+        }
+    }
+
+    public class UiModuleWebListener implements WebListener {
+        long lastId = -1;
+        @Override
+        public void webEvent(WebEvent event) {
+            try {
+                if (event.getType() == WebEvent.DEPLOYING && lastId != event.getBundleId()) {
+                    // on deployment of new bundles check whether they are UI modules
+                    // (this seems to be called about 10 times for any deployment; keep a note of the last bundle id to avoid duplication
+                    lastId = event.getBundleId();
+                    URL config = event.getBundle().getResource(CONFIG_PATH);
+                    if (config!=null) {
+                        LOG.trace("WebListener on deploying UI module "+event.getBundle().getSymbolicName()+" ["+event.getBundleId()+"] "
+                            + "to "+event.getContextPath()+", checking whether any bundles need stopping");
+                        stopAnyExistingOrSuperseded(createUiModule(config.openStream(), event.getContextPath()), event.getBundle());
+                    }
+                }
+            } catch (Exception e) {
+                if (!isBundleStartingOrActive(event.getBundle())) {
+                    LOG.debug("Error listening to UI module bundle "+event.getBundleName()+" in state "+event.getBundle().getState()+" (not starting/active, so not a serious problem, esp if we just stopped it): "+e);
+                } else {
+                    LOG.warn("Error listening to UI module bundle "+event.getBundleName()+" start: "+e, e);
+                }
+            }
+        }
+    }
     
+    protected void stopAnyExistingOrSuperseded(final UiModule uiModule, final Bundle bundle) throws Exception {
+        if (uiModule.getStopExisting()) {
+            stopExistingModulesListeningOnOurEndpoint(bundle, uiModule);
+        }
+        if (!uiModule.getSupersedesBundles().isEmpty()) {
+            stopSupersededBundles(bundle, uiModule);
+        }
+    }
+    
+    /** stop modules on the same endpoint that with a lower number ID;
+     * or if a module supersedes us, stop ourselves */
+    private void stopExistingModulesListeningOnOurEndpoint(Bundle bundle, UiModule uiModule) throws Exception {
+        ServiceReference<WebContainerService> webS = bundle.getBundleContext().getServiceReference(WebContainerService.class);
+        WebContainerService web = bundle.getBundleContext().getService(webS);
+        
+        for (WebBundle bi: web.list()) {
+            if (bi.getBundleId()==bundle.getBundleId()) continue;
+            if (uiModule.getPath().equals(bi.getContextPath()) || (uiModule.getPath().equals("") && bi.getContextPath().equals("/"))) {
+                Bundle bb = bundle.getBundleContext().getBundle(bi.getBundleId());
+                Collection<ServiceReference<UiModule>> modules = bundle.getBundleContext().getServiceReferences(UiModule.class, null);
+                for (ServiceReference<UiModule> modS: modules) {
+                    if (modS.getBundle()!=null && modS.getBundle().getBundleId()==bi.getBundleId()) {
+                        // found UiModule for the potentially conflicting bundle
+                        UiModule mod = bundle.getBundleContext().getService(modS);
+                        if (isBundleSuperseded(mod, bundle)) {
+                            // if that module supersedes us, don't stop them, stop us!
+                            stopBundle(bundle, "context path "+bi.getContextPath()+" is in use by "+bb.getSymbolicName()+" ["+bb.getBundleId()+"]");
+                            return;
+                        }
+                    }
+                }
+                if (bb.getBundleId() < bundle.getBundleId()) {
+                    // in case of context-path conflict with no declared supersedes relationship, prefer the higher number (later installed)
+                    stopBundle(bb, "context path "+bi.getContextPath()+" is needed for installation of "+bundle.getSymbolicName()+" ["+bundle.getBundleId()+"]");
+                }
+            }
+        }
+    }
+
+    /** stop modules superseded by us */
+    private void stopSupersededBundles(Bundle bundle, UiModule uiModule) {
+        LOG.trace("Calling stopSuperseded on install of "+bundle.getSymbolicName()+"; will stop any of "+uiModule.getSupersedesBundles());
+        for (Bundle b: bundle.getBundleContext().getBundles()) {
+            if (b.getBundleId()==bundle.getBundleId()) continue;
+            if (isBundleSuperseded(uiModule, b)) {
+                stopBundle(b, "it is superseded by "+bundle.getSymbolicName()+" ["+bundle.getBundleId()+"]");
+            }
+        }
+    }
+
+    private boolean isBundleSuperseded(UiModule module, Bundle bundle) {
+        if (module.getSupersedesBundles()!=null) {
+            for (String superseded: module.getSupersedesBundles()) {
+                String bn = superseded;
+                String version = null;
+                int split = bn.indexOf(':');
+                if (split>=0) {
+                    version = bn.substring(split+1);
+                    bn = bn.substring(0, split);
+                }
+                if (bundle.getSymbolicName().matches(bn) && (version==null || bundle.getVersion().toString().matches(version))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    protected void stopBundle(Bundle bundleToStop, String reason) {
+        boolean isActive = isBundleStartingOrActive(bundleToStop);
+        String message = "stopping bundle "+bundleToStop.getSymbolicName()+" ["+bundleToStop.getBundleId()+"]; "+reason;
+        if (!isActive) {
+            LOG.trace("Not "+message+"; but that conflicting bundle is not starting or active");
+            // if it tries to start it should abort itself
+            return;
+        }
+        LOG.info("UiModules: " + message);
+        new Thread(() -> { 
+            try {
+                bundleToStop.stop(); 
+            } catch (Exception e) {
+                LOG.warn("UiModules: error "+message+": "+e, e);
+            }
+        }).start();
+    }
+
+    protected boolean isBundleStartingOrActive(Bundle bundleToStop) {
+        switch (bundleToStop.getState()) {
+        case Bundle.START_TRANSIENT:
+        case Bundle.STARTING:
+        case Bundle.ACTIVE:
+            return true;
+        }
+        return false;
+    }
+
     private void blockUntilBundleStarted(final Bundle bundle, Duration timeout) throws InterruptedException {
         long endTime = System.currentTimeMillis() + timeout.toMillis();
         do {
@@ -90,7 +232,7 @@ public class UiModuleListener implements ServletContextListener {
         
     @Override
     public void contextDestroyed(ServletContextEvent servletContextEvent) {
-        LOG.info("Un-Registering Brooklyn UI module at [{}]", servletContextEvent.getServletContext().getContextPath());
+        LOG.info("Unregistering Brooklyn UI module at [{}]", servletContextEvent.getServletContext().getContextPath());
         if (registration != null) {
             try {
                 registration.unregister();
@@ -108,6 +250,10 @@ public class UiModuleListener implements ServletContextListener {
     private UiModule createUiModule(ServletContext servletContext) {
         final InputStream is = servletContext.getResourceAsStream(CONFIG_PATH);
         final String path = servletContext.getContextPath();
+        return createUiModule(is, path);
+    }
+
+    protected UiModule createUiModule(final InputStream is, final String path) {
         if (is == null) {
             throw new RuntimeException(String.format("Module on path [%s] will not be registered as it does not have any configuration", path));
         }

--- a/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/internal/UiModuleImpl.java
+++ b/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/internal/UiModuleImpl.java
@@ -19,23 +19,25 @@
 package org.apache.brooklyn.ui.modularity.module.api.internal;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
-
 import org.apache.brooklyn.ui.modularity.module.api.UiModule;
 import org.apache.brooklyn.ui.modularity.module.api.UiModuleAction;
+
+import com.google.common.base.Optional;
 
 public class UiModuleImpl implements UiModule {
     private String id;
     private String name;
     private String slug;
     private String icon;
-    private Set<String> types = new HashSet<>();
+    private Set<String> types = new LinkedHashSet<>();
+    private Set<String> supersedesBundles = new LinkedHashSet<>();
+    private boolean stopExisting = true;
     private String path;
     private List<UiModuleAction> actions = new ArrayList<>();
 
@@ -49,7 +51,16 @@ public class UiModuleImpl implements UiModule {
         if (types != null && types instanceof List) {
             @SuppressWarnings("unchecked")
             List<String> typesTyped = (List<String>) types;
-            result.setTypes(new HashSet<String>(typesTyped));
+            result.setTypes(new LinkedHashSet<String>(typesTyped));
+        }
+        final Object supersedes = incomingMap.get("supersedes");
+        if (supersedes != null && supersedes instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<String> supersedesTyped = (List<String>) supersedes;
+            result.setSupersedesBundles(new LinkedHashSet<String>(supersedesTyped));
+        }
+        if (incomingMap.containsKey("stopExisting")) {
+            result.setStopExisting(Boolean.getBoolean((String) incomingMap.get("stopExisting")));
         }
         final Object actions = incomingMap.get("actions");
         if (actions != null && actions instanceof List) {
@@ -88,6 +99,16 @@ public class UiModuleImpl implements UiModule {
     }
 
     @Override
+    public Set<String> getSupersedesBundles() {
+        return supersedesBundles;
+    }
+    
+    @Override
+    public boolean getStopExisting() {
+        return stopExisting;
+    }
+
+    @Override
     public String getPath() {
         return path;
     }
@@ -115,6 +136,14 @@ public class UiModuleImpl implements UiModule {
 
     public void setTypes(final Set<String> types) {
         this.types = types;
+    }
+
+    public void setSupersedesBundles(final Set<String> supersedesBundles) {
+        this.supersedesBundles = supersedesBundles;
+    }
+    
+    public void setStopExisting(final boolean stopExisting) {
+        this.stopExisting = stopExisting;
     }
 
     public void setPath(String path) {

--- a/ui-modules/home/app/views/main/main.controller.js
+++ b/ui-modules/home/app/views/main/main.controller.js
@@ -55,9 +55,7 @@ export function mainStateConfig($stateProvider) {
 export function mainStateController($scope, $state, uiModules, catalogApps) {
     $scope.$emit(HIDE_INTERSTITIAL_SPINNER_EVENT);
 
-    this.uiModules = uiModules.filter((uiModule) => {
-        return uiModule.types.indexOf('home-ui-module') > -1;
-    });
+    this.uiModules = uiModules.filter( (uiModule) => uiModule.types.includes('home-ui-module') );
     this.catalogApps = catalogApps;
 
     this.pagination = {

--- a/ui-modules/home/src/main/resources/ui-module/config.yaml
+++ b/ui-modules/home/src/main/resources/ui-module/config.yaml
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name: Home
+slug: ${project.artifactId}
+icon: fa-home

--- a/ui-modules/home/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/home/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,10 @@
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
 
+    <listener>
+        <listener-class>org.apache.brooklyn.ui.modularity.module.api.UiModuleListener</listener-class>
+    </listener>
+
     <!--FILTERS :: START-->
     <filter>
         <filter-name>ui-module-filter</filter-name>

--- a/ui-modules/utils/module-links/module-links-drawer.template.html
+++ b/ui-modules/utils/module-links/module-links-drawer.template.html
@@ -17,8 +17,8 @@
   under the License.
 -->
 <div class="ui-module-nav-drawer-container">
-    <div ng-repeat="module in modules track by id" ng-if="modules">
-        <a ng-href="module.path" ng-if="module.path">
+    <div ng-repeat="module in modules track by id" ng-if="module.path && !module.type.includes('library-ui-module')">
+        <a ng-href="module.path">
             <i class="module-icon fa {{module.icon}}"></i>
             <div class="module-name">{{module.name}}</div>
         </a>

--- a/ui-modules/utils/module-links/module-links-drawer.template.html
+++ b/ui-modules/utils/module-links/module-links-drawer.template.html
@@ -18,7 +18,7 @@
 -->
 <div class="ui-module-nav-drawer-container">
     <div ng-repeat="module in modules track by id" ng-if="modules">
-        <a ng-href="module.path">
+        <a ng-href="module.path" ng-if="module.path">
             <i class="module-icon fa {{module.icon}}"></i>
             <div class="module-name">{{module.name}}</div>
         </a>

--- a/ui-modules/utils/module-links/module-links-navbar.template.html
+++ b/ui-modules/utils/module-links/module-links-navbar.template.html
@@ -38,8 +38,8 @@
         <i class="ui-module-icon fa fa-fw fa-home"></i>
         <span class="ui-module-name">Home</span>
     </a></li>
-    <li role="menuitem" ng-repeat="module in ctrl.modules track by module.id">
-        <a ng-href="{{module.path}}" class="module" ng-class="{active: ctrl.isModuleActive(module.path)}" ng-if="module.path">
+    <li role="menuitem" ng-repeat="module in ctrl.modules track by module.id" ng-if="module.path && !module.type.includes('library-ui-module')">
+        <a ng-href="{{module.path}}" class="module" ng-class="{active: ctrl.isModuleActive(module.path)}">
             <i class="ui-module-icon fa fa-fw {{module.icon}}"></i>
             <span class="ui-module-name">{{module.name}}</span>
         </a>

--- a/ui-modules/utils/module-links/module-links-navbar.template.html
+++ b/ui-modules/utils/module-links/module-links-navbar.template.html
@@ -33,12 +33,13 @@
     </span>
 </a>
 <ul class="dropdown-menu ui-modules" uib-dropdown-menu>
+    <!-- put home first -->
     <li role="menuitem"><a href="/" ng-class="{active: ctrl.isModuleActive('/')}">
         <i class="ui-module-icon fa fa-fw fa-home"></i>
         <span class="ui-module-name">Home</span>
     </a></li>
     <li role="menuitem" ng-repeat="module in ctrl.modules track by module.id">
-        <a ng-href="{{module.path}}" class="module" ng-class="{active: ctrl.isModuleActive(module.path)}">
+        <a ng-href="{{module.path}}" class="module" ng-class="{active: ctrl.isModuleActive(module.path)}" ng-if="module.path">
             <i class="ui-module-icon fa fa-fw {{module.icon}}"></i>
             <span class="ui-module-name">{{module.name}}</span>
         </a>

--- a/ui-modules/utils/module-links/module-links.js
+++ b/ui-modules/utils/module-links/module-links.js
@@ -53,8 +53,8 @@ export function moduleLinksMenuDirective($compile) {
     function controller(brBrandInfo, brooklynUiModulesApi) {
         this.modules = null;
         this.isModuleActive = (path) => {
-            if (path === '/') {
-                return window.location.pathname === path;
+            if (path === '/' || path === '') {
+                return window.location.pathname === '/';
             } else {
                 return window.location.pathname.startsWith(path);
             }


### PR DESCRIPTION
Either by stopping other bundles listening on the same context-path or by specifying bundles superseded by a module being installed.  See `README.md` for more info.