### PR TITLE
Restore slf4j.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
         <node.version>v8.4.0</node.version>
         <npm.version>5.4.1</npm.version>
 
+        <slf4j.version>1.7.14</slf4j.version>
+
     </properties>
 
     <build>


### PR DESCRIPTION
The brooklyn-ui-utils module wouldn't build on a mvn clean install with this property missing.