### PR TITLE
Fix bug with the DSL editor/viewer

### DIFF
--- a/ui-modules/blueprint-composer/app/components/dsl-viewer/dsl-viewer.js
+++ b/ui-modules/blueprint-composer/app/components/dsl-viewer/dsl-viewer.js
@@ -51,7 +51,16 @@ export function dslViewerDirective() {
             return [KIND.STRING, KIND.NUMBER].includes(dsl.kind);
         };
         scope.getRelatedEntity = () => {
-            return scope.dsl.getRoot().relationships.find(entity => entity.id === scope.dsl.params[0].name);
+            if (scope.dsl.params.length > 0) {
+                // If the DSL is looking at an entity ID
+                return scope.dsl.getRoot().relationships.find(entity => entity.id === scope.dsl.params[0].name)
+            } else if (scope.dsl.getRoot().relationships.length > 0) {
+                // If the DSL is of the form $brooklyn:self() or $brooklyn:parent()
+                return scope.dsl.getRoot().relationships[0];
+            } else {
+                // Otherwise, there is no related entity
+                return null;
+            }
         }
     }
 }

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/dsl/edit.dsl.controller.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/dsl/edit.dsl.controller.js
@@ -159,7 +159,7 @@ export const graphicalEditDslState = {
             if (!view) {
                 view = {
                     name: $state.current.name,
-                    params: $state.params
+                    params: angular.copy($state.params)
                 };
                 objectCache.put(`${definition.name}.view`, view);
             }


### PR DESCRIPTION
This fixes 2 bugs:
1. When adding a DSL for an entity spec, The DSL editor "Done" button was not redirecting to the spec editor. This was due to the previous param object being modified later on by the `ui-router`. Creating a deep copy of the object avoid this
2. The DSL viewer was throwing an error while getting the name of the entity for DSL like `$brooklyn:self()` or `$brooklyn:parent()`. This is fixed by looking up directly for the relationships if the DSL are of that form