### PR TITLE
Blueprint composer deletes entities with backspace/delete key

### DIFF
--- a/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
+++ b/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
@@ -173,6 +173,11 @@ export function designerDirective($log, $state, $q, iconGenerator, catalogApi, b
             });
         });
 
+        $element.bind('delete-entity', function (event) {
+            $log.debug('delete-entity');
+            $scope.$broadcast('d3.remove', event.detail.entity);
+        });
+
         $element.bind('drop-external-node', event => {
             let draggedItem = paletteDragAndDropService.draggedItem();
             let target = blueprintService.find(event.detail.parentId);

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -323,7 +323,6 @@ export function D3Blueprint(container) {
         d3.event.stopPropagation();
         if (d3.event.target.nodeName == 'BODY') {
             if (d3.event.key === "Delete" || d3.event.key === "Backspace") {
-                // the selected entity:
                 var selected = _svg.selectAll('.entity.selected');
                 var nItemsSelected = selected._groups[0].length;
                 if (nItemsSelected > 0) {
@@ -332,7 +331,7 @@ export function D3Blueprint(container) {
                               entity: selected.data()[0].data,
                           }
                       });
-                      container.dispatchEvent(event);
+                    container.dispatchEvent(event);
                 }
             }
         }

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -314,6 +314,34 @@ export function D3Blueprint(container) {
     }
 
     /**
+     * Triggered when a key is release on the page.
+     *
+     * * Ignores where key press did not originate from the page body (i.e. ignores input to text fields)
+     * * Fires a custom event "delete-entity" when the delete key is pressed.
+     */
+    function onKeyUp() {
+        d3.event.stopPropagation();
+        if (d3.event.target.nodeName == 'BODY') {
+            if (d3.event.key === "Delete" || d3.event.key === "Backspace") {
+                console.log('-- DELETE/BACKSPACE key outside of text field --');
+                // the selected entity:
+                var selected = _svg.selectAll('.entity.selected');
+                var nItemsSelected = selected._groups[0].length;
+                if (nItemsSelected > 0) {
+                    console.log('Dispatch event to remove node(s)');
+                    // entity = ...
+                    // let event = new CustomEvent("delete-entity", {
+                    //      detail: {
+                    //          entity: entity,
+                    //      }
+                    //  });
+                    //  container.dispatchEvent(event);
+                }
+            }
+        }
+    }
+
+    /**
      * Handles the start of a drag operation. Note that this callback is to be used with the internal D3 drag feature.
      *
      * @param node The node for the dragged entity
@@ -1010,6 +1038,9 @@ export function D3Blueprint(container) {
     function showDropzones() {
         _dropZoneGroup.selectAll('.dropzone').classed('hidden', false);
     }
+
+    // register global key events
+    d3.select('body').on('keyup.body', onKeyUp);
 
     return {
         draw: draw,

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -323,19 +323,16 @@ export function D3Blueprint(container) {
         d3.event.stopPropagation();
         if (d3.event.target.nodeName == 'BODY') {
             if (d3.event.key === "Delete" || d3.event.key === "Backspace") {
-                console.log('-- DELETE/BACKSPACE key outside of text field --');
                 // the selected entity:
                 var selected = _svg.selectAll('.entity.selected');
                 var nItemsSelected = selected._groups[0].length;
                 if (nItemsSelected > 0) {
-                    console.log('Dispatch event to remove node(s)');
-                    // entity = ...
-                    // let event = new CustomEvent("delete-entity", {
-                    //      detail: {
-                    //          entity: entity,
-                    //      }
-                    //  });
-                    //  container.dispatchEvent(event);
+                    let event = new CustomEvent("delete-entity", {
+                          detail: {
+                              entity: selected.data()[0].data,
+                          }
+                      });
+                      container.dispatchEvent(event);
                 }
             }
         }


### PR DESCRIPTION
As a blueprint author
I want to be able to delete entities present on the graphic view of the Blueprint Composer by hitting the backspace/delete key on my keyboard
So that I can write blueprints faster (especially as a user who prefers keyboards to mice).