### PR TITLE
recognize memberSpec anywhere, and refresh blueprint within yaml editor

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -79,6 +79,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         }
         setBlueprintFromJson(newBlueprint);
         $log.debug(TAG + 'Blueprint set from YAML', blueprint);
+        // TODO refresh the blueprint now?  see comments in yaml.state.js and on refreshBlueprint
     }
 
     function getBlueprint() {
@@ -195,6 +196,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
     }
 
     function refreshBlueprintMetadata(entity = blueprint, family = 'ENTITY') {
+        // TODO ideally we'd have a cache for all types
         return refreshEntityMetadata(entity, family).then(()=> {
             return $q.all(entity.children.reduce((result, child) => {
                 result.push(refreshBlueprintMetadata(child));

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -302,13 +302,11 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
 
     function refreshConfigMemberspecsMetadata(entity) {
         let promiseArray = [];
-        if (entity.isCluster()) {
-            Object.values(entity.getClusterMemberspecEntities()).forEach((memberSpec)=> {
-                // memberSpec can be `undefined` if the member spec is not a `$brooklyn:entitySpec`, e.g. it is `$brooklyn:config("spec")`.
-                // there may be a better way but this seems to handle it.
-                if (memberSpec) promiseArray.push(refreshBlueprintMetadata(memberSpec, 'SPEC'));
-            });
-        }
+        Object.values(entity.getClusterMemberspecEntities()).forEach((memberSpec)=> {
+            // memberSpec can be `undefined` if the member spec is not a `$brooklyn:entitySpec`, e.g. it is `$brooklyn:config("spec")`.
+            // there may be a better way but this seems to handle it.
+            if (memberSpec) promiseArray.push(refreshBlueprintMetadata(memberSpec, 'SPEC'));
+        });
         return $q.all(promiseArray);
     }
 

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -19,9 +19,10 @@
 import {Issue} from './issue.model';
 import {Dsl, DslParser} from './dsl.model';
 
-const MEMBERSPEC_REGEX = /^(\w+\.)+[mM]ember[sS]pec$/;
-const FIRST_MEMBERSPEC_REGEX = /^(\w+\.)+first[mM]ember[sS]pec$/;
-const ANY_MEMBERSPEC_REGEX = /^(\w+\.)+(first)?[mM]ember[sS]pec$/;
+const MEMBERSPEC_REGEX = /^(\w+\.)*[mM]ember[sS]pec$/;
+const FIRST_MEMBERSPEC_REGEX = /^(\w+\.)*first[mM]ember[sS]pec$/;
+// TODO ideally we'd just look at type EntitySpec, not key name, but for now look at keyname, anything ending memberSpec
+const ANY_MEMBERSPEC_REGEX = /^(\w+\.?)*[mM]ember[sS]pec$/;
 const RESERVED_KEY_REGEX = /(^children$|^services$|^locations?$|^brooklyn\.config$|^brooklyn\.enrichers$|^brooklyn\.policies$)/;
 const FIELD = {
     SERVICES: 'services', CHILDREN: 'brooklyn.children', CONFIG: 'brooklyn.config', LOCATION: 'location',
@@ -115,6 +116,8 @@ export class Entity {
      *
      */
     touch() {
+        // include a summary to aid with debugging (otherwise log just shows the property lastUpdated)
+        this.summary = (this.type || "unset") + (this.id ? " "+this.id : "");
         this.lastUpdated = new Date().getTime();
         if (this.hasParent()) {
             this.parent.touch();
@@ -633,7 +636,6 @@ function isCluster() {
         return false;
     }
     let traits = MISC_DATA.get(this).get('traits');
-
     return traits && traits.filter((trait)=> {
         return ['org.apache.brooklyn.entity.group.Cluster',
                 'org.apache.brooklyn.entity.group.Fabric']

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -116,8 +116,9 @@ export class Entity {
      *
      */
     touch() {
-        // include a summary to aid with debugging (otherwise log just shows the property lastUpdated)
-        this.summary = (this.type || "unset") + (this.id ? " "+this.id : "");
+        //// uncomment the line below to include a summary to aid with debugging 
+        //// (otherwise log just shows the property lastUpdated, until you expand)
+        // this.summary = (this.type || "unset") + (this.id ? " "+this.id : "");
         this.lastUpdated = new Date().getTime();
         if (this.hasParent()) {
             this.parent.touch();

--- a/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
@@ -46,7 +46,12 @@ function yamlStateController($scope, $rootScope, $timeout, blueprintService, brS
 
             try {
                 blueprintService.setFromYaml(cm.getValue(), true);
-                blueprintService.refreshBlueprintMetadata();
+                //// the model of types etc is not updated in the YAML view; the line below will fix this
+                //// but it makes 1 request per type (even if duplicated) on _every_ keypress (modulo a minor debounce)
+                //// so it isn't worth it for now.  we should have a cache at which point the below could be supported again.
+                //// also it might make sense to do it in the `setFromYaml` method above instead of explicitly below.  
+                // blueprintService.refreshBlueprintMetadata();
+                
             } catch (err) {
                 if (!(err instanceof YAMLException)) {
                     issues.push({

--- a/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
@@ -46,6 +46,7 @@ function yamlStateController($scope, $rootScope, $timeout, blueprintService, brS
 
             try {
                 blueprintService.setFromYaml(cm.getValue(), true);
+                blueprintService.refreshBlueprintMetadata();
             } catch (err) {
                 if (!(err instanceof YAMLException)) {
                     issues.push({


### PR DESCRIPTION
makes it easier for other entities to work with memberSpecs, in composer or yaml editor