### PR TITLE
Support for karaf 4.2.1 and running under JDK 11

### DIFF
--- a/modularity-server/external-modules/pom.xml
+++ b/modularity-server/external-modules/pom.xml
@@ -107,7 +107,6 @@
                         <Export-Package>
                             !*
                         </Export-Package>
-                        <Service-Component>*</Service-Component>
                     </instructions>
                 </configuration>
             </plugin>

--- a/modularity-server/features/pom.xml
+++ b/modularity-server/features/pom.xml
@@ -176,7 +176,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.karaf.tooling</groupId>
                         <artifactId>karaf-maven-plugin</artifactId>
-                        <versionRange>[4.1.6,)</versionRange>
+                        <versionRange>[4.2.1,)</versionRange>
                         <goals>
                           <goal>verify</goal>
                           <goal>features-generate-descriptor</goal>

--- a/modularity-server/metadata-registry/pom.xml
+++ b/modularity-server/metadata-registry/pom.xml
@@ -107,7 +107,6 @@
                         <Export-Package>
                             !*
                         </Export-Package>
-                        <Service-Component>*</Service-Component>
                     </instructions>
                 </configuration>
             </plugin>

--- a/modularity-server/module-api/pom.xml
+++ b/modularity-server/module-api/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>
             <artifactId>pax-web-spi</artifactId>
-            <version>6.0.6</version>  <!-- as it's provided we just need compile support; runtime is pulled in by karaf -->
+            <version>${pax-web.version}</version>  <!-- as it's provided we just need compile support; runtime is pulled in by karaf -->
             <scope>provided</scope>
         </dependency>
 

--- a/modularity-server/module-api/pom.xml
+++ b/modularity-server/module-api/pom.xml
@@ -72,7 +72,6 @@
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>
             <artifactId>pax-web-spi</artifactId>
-            <version>${pax-web.version}</version>  <!-- as it's provided we just need compile support; runtime is pulled in by karaf -->
             <scope>provided</scope>
         </dependency>
 

--- a/modularity-server/module-api/pom.xml
+++ b/modularity-server/module-api/pom.xml
@@ -72,6 +72,7 @@
         <dependency>
             <groupId>org.ops4j.pax.web</groupId>
             <artifactId>pax-web-spi</artifactId>
+            <version>${pax-web.version}</version>  <!-- as it's provided we just need compile support; runtime is pulled in by karaf -->
             <scope>provided</scope>
         </dependency>
 

--- a/modularity-server/proxy/pom.xml
+++ b/modularity-server/proxy/pom.xml
@@ -135,7 +135,6 @@
                         <Export-Package>
                             !*
                         </Export-Package>
-                        <Service-Component>*</Service-Component>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <maven-war-plugin.version>3.0.0</maven-war-plugin.version>
         <frontend-maven-plugin.version>1.3</frontend-maven-plugin.version>
+        <pax-web.version>7.2.3</pax-web.version>
         <pax-web-extender-whiteboard.version>${pax-web.version}</pax-web-extender-whiteboard.version>
 
         <!-- new deps not used in brooklyn-server -->

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <maven-war-plugin.version>3.0.0</maven-war-plugin.version>
         <frontend-maven-plugin.version>1.3</frontend-maven-plugin.version>
-        <pax-web.version>6.0.6</pax-web.version>
         <pax-web-extender-whiteboard.version>${pax-web.version}</pax-web-extender-whiteboard.version>
 
         <!-- new deps not used in brooklyn-server -->

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <maven-war-plugin.version>3.0.0</maven-war-plugin.version>
         <frontend-maven-plugin.version>1.3</frontend-maven-plugin.version>
-        <pax-web-extender-whiteboard.version>6.0.6</pax-web-extender-whiteboard.version>
+        <pax-web.version>6.0.6</pax-web.version>
+        <pax-web-extender-whiteboard.version>${pax-web.version}</pax-web-extender-whiteboard.version>
 
         <!-- new deps not used in brooklyn-server -->
         <node.version>v8.4.0</node.version>


### PR DESCRIPTION
Works with apache/brooklyn-server#1002

Removes the use of a `Service-Component` which is no longer supported by `karaf`.

Specifies the pax-web component versions as a property.