### PR TITLE
Composer palette: search entity tags

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -22,7 +22,7 @@ import template from './catalog-selector.template.html';
 
 const ITEMS_PER_PAGE = 30;
 // fields in either bundle or type record:
-const FIELDS_TO_SEARCH = ['name', 'displayName', 'symbolicName', 'version', 'type', 'supertypes', 'containingBundle', 'description', 'displayTags'];
+const FIELDS_TO_SEARCH = ['name', 'displayName', 'symbolicName', 'version', 'type', 'supertypes', 'containingBundle', 'description', 'displayTags', 'tags'];
 
 export function catalogSelectorDirective() {
     return {


### PR DESCRIPTION
The palette should also search the entity's tags, when filtering. People can use tags to categorise or provide additional metadata, so this is useful to include.