### PR TITLE
Implement missing endpoint for palette API

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/palette-api.js
+++ b/ui-modules/blueprint-composer/app/components/providers/palette-api.js
@@ -33,7 +33,12 @@ export class PaletteApi {
         return Promise.resolve();
     }
 
-    getTypeVersion(typeSymbolicName) {
+    getTypeVersions(typeSymbolicName) {
+        // no-op
+        return Promise.resolve();
+    }
+
+    getBundle(bundleSymbolicName, bundleVersion) {
         // no-op
         return Promise.resolve();
     }

--- a/ui-modules/blueprint-composer/app/components/providers/palette-api.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/palette-api.provider.js
@@ -58,8 +58,12 @@ class PaletteApiProvider extends PaletteApi {
         return this.catalogApi.getType(typeSymbolicName, typeVersion);
     }
 
-    getTypeVersion(typeSymbolicName) {
-        return this.catalogApi.getTypeVersion(typeSymbolicName);
+    getTypeVersions(typeSymbolicName) {
+        return this.catalogApi.getTypeVersions(typeSymbolicName);
+    }
+
+    getBundle(bundleSymbolicName, bundleVersion) {
+        return this.catalogApi.getBundle(bundleSymbolicName, bundleVersion);
     }
 
     getBundleType(bundleSymbolicName, bundleVersion, typeSymbolicName, typeVersion) {


### PR DESCRIPTION
The palette API was missing crucial endpoints used to load blueprint from the catalog UI module.

This also fixes a typo in for the `getTypeVersions` method name => `s/getTypeVersion/getTypeVersions`