### PR TITLE
Fix firefox multi-lines issue in configuration text-area

### DIFF
--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -601,7 +601,7 @@ spec-editor {
     }
     textarea.auto-grow-multi-row {
         // multi-line entries shouldn't wrap
-        white-space: nowrap;
+        white-space: pre;
     }
 
     .collapsing {  transition: height 0.15s; }

--- a/ui-modules/utils/autogrow/index.js
+++ b/ui-modules/utils/autogrow/index.js
@@ -54,11 +54,15 @@ export function autoGrowDirective() {
         };
 
         element.bind('keydown keypress', e => {
-            if (e.which === 13 && (e.ctrlKey || e.metaKey)) {
+            if (e.which === 13 && (e.ctrlKey || e.shiftKey || e.metaKey)) {
                 e.preventDefault();
                 e.stopPropagation();
                 let cursorPosition = element[0].selectionStart;
-                ctrl.$setViewValue(ctrl.$modelValue.substring(0, cursorPosition) + "\n" + ctrl.$modelValue.substring(cursorPosition));
+                if (ctrl.$modelValue === undefined) {
+                    ctrl.$setViewValue("\n");
+                } else {
+                    ctrl.$setViewValue(ctrl.$modelValue.substring(0, cursorPosition) + "\n" + ctrl.$modelValue.substring(cursorPosition));
+                }
                 ctrl.$render();
                 scope.$apply(() => {
                     element[0].selectionEnd = cursorPosition + 1;

--- a/ui-modules/utils/on-enter/index.js
+++ b/ui-modules/utils/on-enter/index.js
@@ -36,7 +36,7 @@ export function onEnterDirective() {
 
     function link(scope, element, attrs) {
         element.bind("keydown keypress", event => {
-            if (event.which === 13 && !event.ctrlKey && !event.metaKey) {
+            if (event.which === 13 && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
                 scope.onEnter(element, event);
             }
         });


### PR DESCRIPTION
Fix firefox multi-lines issue in configuration text-area in the blueprint composer

- replace white-space "nowrap" by "pre" otherwise firefox doesn't display new lines
- handle shift+enter (in addition to ctrl+enter and option+enter) to create a new line
- avoid javascript error when the input is empty and new line is inserted

Signed-off-by: Ludovic Plantin <ludovic.plantin@usharesoft.com>