### PR TITLE
Fix image animation for memberspec when there are children to the cluster

### DIFF
--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -879,8 +879,6 @@ export function D3Blueprint(container) {
         specNodeData.select('image')
             .transition()
             .duration(_configHolder.transition)
-            .attr('transform', (d)=>(`rotate(${d.data.hasChildren() ? 45 : 0})`))
-            .attr('transform-origin', 0)
             .attr('opacity', (d)=>(d.data.getClusterMemberspecEntity(PREDICATE_MEMBERSPEC).hasIcon() ? 1 : 0))
             .attr('xlink:href', (d)=>(d.data.getClusterMemberspecEntity(PREDICATE_MEMBERSPEC).icon));
     }


### PR DESCRIPTION
Previously, there was an issue on the memberspec node's animation when a cluster had more than one child. This fixes it for both Chrome and Firefox

## Before
<img width="1166" alt="screen shot 2018-10-10 at 13 54 16" src="https://user-images.githubusercontent.com/2082759/46737869-8f86c380-cc94-11e8-8f36-8d59b848dbe6.png">

## After
<img width="1166" alt="screen shot 2018-10-10 at 13 53 09" src="https://user-images.githubusercontent.com/2082759/46737879-94e40e00-cc94-11e8-8860-995e750782ca.png">
