### PR TITLE
Fix the remove button within overflow menu for adjuncts

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -228,7 +228,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         let deferred = $q.defer();
 
         if (entity.hasType()) {
-            entity.family = family;
+            entity.family = family.id;
 
             let promise = entity.miscData.has('bundle')
                 ? paletteApi.getBundleType(entity.miscData.get('bundle').symbolicName, entity.miscData.get('bundle').version, entity.type, entity.version)

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -27,13 +27,14 @@ import {RESERVED_KEYS, DSL_ENTITY_SPEC} from '../providers/blueprint-service.pro
 import brooklynDslEditor from '../dsl-editor/dsl-editor';
 import brooklynDslViewer from '../dsl-viewer/dsl-viewer';
 import template from './spec-editor.template.html';
+import {graphicalState} from '../../views/main/graphical/graphical.state';
 
 const MODULE_NAME = 'brooklyn.components.spec-editor';
 const ANY_MEMBERSPEC_REGEX = /(^.*[m,M]ember[s,S]pec$)/;
 const REPLACED_DSL_ENTITYSPEC = '___brooklyn:entitySpec';
 
 angular.module(MODULE_NAME, [onEnter, autoGrow, blurOnEnter, brooklynDslEditor, brooklynDslViewer])
-    .directive('specEditor', ['$rootScope', '$templateCache', '$injector', '$sanitize', '$filter', '$log', '$sce', '$timeout', '$document', 'blueprintService', specEditorDirective])
+    .directive('specEditor', ['$rootScope', '$templateCache', '$injector', '$sanitize', '$filter', '$log', '$sce', '$timeout', '$document', '$state', 'blueprintService', specEditorDirective])
     .filter('specEditorConfig', specEditorConfigFilter)
     .filter('specEditorType', specEditorTypeFilter);
 
@@ -71,7 +72,7 @@ export const CONFIG_FILTERS = [
     }
 ];
 
-export function specEditorDirective($rootScope, $templateCache, $injector, $sanitize, $filter, $log, $sce, $timeout, $document, blueprintService) {
+export function specEditorDirective($rootScope, $templateCache, $injector, $sanitize, $filter, $log, $sce, $timeout, $document, $state, blueprintService) {
     return {
         restrict: 'E',
         scope: {
@@ -332,8 +333,19 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             }
         };
 
-        scope.removeEntity = ()=> {
-            $rootScope.$broadcast('d3.remove', scope.model);
+        scope.removeModel = ()=> {
+            switch (scope.model.family) {
+                case EntityFamily.ENRICHER:
+                    scope.model.parent.removeEnricher(scope.model._id);
+                    break;
+                case EntityFamily.POLICY:
+                    scope.model.parent.removePolicy(scope.model._id);
+                    break;
+                default:
+                    $rootScope.$broadcast('d3.remove', scope.model);
+                    break;
+            }
+            $state.go(graphicalState.name);
         };
 
         scope.getConfigIssues = specEditor.getConfigIssues = ()=> {

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -29,7 +29,7 @@
             <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="spec-actions">
                 <li role="menuitem"><a ng-href="/brooklyn-ui-catalog/#!/bundles/{{model.miscData.get('bundle').symbolicName}}/{{model.miscData.get('bundle').version}}/types/{{model.type}}/{{model.version || 'latest'}}" target="_blank">Open in Catalog</a></li>
                 <li role="separator" class="divider"></li>
-                <li role="menuitem"><a href ng-click="removeEntity()"><span class="text-danger">Delete</span></a></li>
+                <li role="menuitem"><a href ng-click="removeModel()"><span class="text-danger">Delete</span></a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
Previously, the `Remove` item present within the overflow menu (top right) of the `spec-editor` wasn't removing an adjunct. There was 2 issues causing this behaviour:
1. The `Remove` item wasn't checking the entity family, hence didn't delete any adjunct (as methods are different than removing a child)
2. The `refreshTypeMetadata` was setting the wrong entity family for adjuncts