### PR TITLE
Allow to resolve different virtual type according to the entity configuration

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -232,7 +232,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
 
             let promise = entity.miscData.has('bundle')
                 ? paletteApi.getBundleType(entity.miscData.get('bundle').symbolicName, entity.miscData.get('bundle').version, entity.type, entity.version)
-                : paletteApi.getType(entity.type, entity.version);
+                : paletteApi.getType(entity.type, entity.version, entity.config);
 
             promise.then((data)=> {
                 deferred.resolve(populateEntityFromApiSuccess(entity, data));

--- a/ui-modules/blueprint-composer/app/components/providers/palette-api.js
+++ b/ui-modules/blueprint-composer/app/components/providers/palette-api.js
@@ -28,7 +28,7 @@ export class PaletteApi {
         return Promise.resolve();
     }
 
-    getType(typeSymbolicName, typeVersion) {
+    getType(typeSymbolicName, typeVersion, config) {
         // no-op
         return Promise.resolve();
     }

--- a/ui-modules/blueprint-composer/app/components/providers/palette-api.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/palette-api.provider.js
@@ -54,7 +54,7 @@ class PaletteApiProvider extends PaletteApi {
         return this.catalogApi.getTypes(params);
     }
 
-    getType(typeSymbolicName, typeVersion) {
+    getType(typeSymbolicName, typeVersion, config) {
         return this.catalogApi.getType(typeSymbolicName, typeVersion);
     }
 


### PR DESCRIPTION
One possible use case of the composer is to have a custom palette that represents several elements ("virutal types") that are based on the same brooklyn type with different brooklyn configuration (referencing different external element like docker image or, in our case, UForge appliance).

In that use case, with the following yaml
```
services:
  - type: com.usharesoft.brooklyn.type.LinuxAppliance
    brooklyn.config:
      applianceUUID: 'AAAA-AAAA-AAAA'
  - type: com.usharesoft.brooklyn.type.LinuxAppliance
    brooklyn.config:
      applianceUUID: 'BBBB-BBBB-BBBB'
  - type: com.usharesoft.brooklyn.type.LinuxAppliance
    brooklyn.config:
      applianceUUID: 'AAAA-AAAA-AAAA'
```
the three services of the same `com.usharesoft.brooklyn.type.LinuxAppliance` brooklyn type should be resolved by two different "virtual" types from the composer point of view, one for the reference `AAAA-AAAA-AAAA` and one for the reference `BBBB-BBBB-BBBB`.

So that graphically we can have when switching from the yaml editor to the graphical editor
![image](https://user-images.githubusercontent.com/22656857/47286412-e1adda00-d5ee-11e8-8456-bdb517e964f1.png)

In order to be able to do that, we need to add an extra third parameters with the entity configuration when the type is resolved by the palette-api provider (when the user switch from the yaml editor to the graphical editor).

In the standard use case of the palette, this extra parameter is ignored and the palette-api simply calls the catalog-api as before.

PS: it's one of my first pull request on the project so don't hesitate to correct me and to tell me the proper way of doing it. Thanks !