### PR TITLE
DSL editor: allow ref to entity anywhere

### DIFF
--- a/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
+++ b/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
@@ -319,15 +319,13 @@ export function dslEditorDirective($rootScope, $filter, $log, brUtilsGeneral, bl
     function getEntityItems(entity, type) {
         let entities = [];
 
-        if (entity.miscData.get('traits').some(trait => trait.match(type)) || !angular.isDefined(type)) {
-            entities.push({
-                id: entity._id,
-                type: DSL_KINDS.ENTITY,
-                entity: entity,
-                name: entity.miscData.get('typeName') || $filter('entityName')(entity) || 'New application',
-                description: entity.description
-            });
-        }
+        entities.push({
+            id: entity._id,
+            type: DSL_KINDS.ENTITY,
+            entity: entity,
+            name: entity.miscData.get('typeName') || $filter('entityName')(entity) || 'New application',
+            description: entity.description
+        });
 
         entities = Object.values(entity.getClusterMemberspecEntities()).reduce((acc, spec) => {
             return acc.concat(getEntityItems(spec, type));


### PR DESCRIPTION
This change means that the DSL editor will let you choose a reference to an entity in any config key (rather than only if the config key is of type `Entity`).

This makes it more consistent with the rest of the DSL editor: e.g. if generating `attributeWhenReady`, it doesn't type-check the attributes' types to filter the view to only those that match the config key's type. This is a good thing, because otherwise we'd have to repeat all the type coercion rules in the UI, for it to know what is legal!

---
I tested this by running `npm run start` in brooklyn-ui/ui-modules/blueprint-composer. I chose a couple of arbitrary entities, and successfully wired up a config key's value to reference the other entity:

<img width="822" alt="dsl-editor-entity-ref" src="https://user-images.githubusercontent.com/593113/47419941-30857c00-d775-11e8-9509-2bc87a8fb146.png">
