### PR TITLE
Expand relationship support to memberspecs

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -625,6 +625,13 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
             };
         });
 
+        relationships = Array.from(entity.config.values())
+            .filter(config => config[DSL_ENTITY_SPEC] && config[DSL_ENTITY_SPEC] instanceof Entity)
+            .map(config => config[DSL_ENTITY_SPEC])
+            .reduce((relationships, spec) => {
+            return relationships.concat(getRelationships(spec));
+        }, relationships);
+
         return entity.children.reduce((relationships, child) => {
             return relationships.concat(getRelationships(child))
         }, relationships);

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -677,7 +677,13 @@ export function D3Blueprint(container) {
      * @return {*} a D3 tree node
      */
     function nodeForEntity(entity) {
-        let node = _d3DataHolder.nodes.find((d)=>(d.data._id === entity._id));
+        let node = _d3DataHolder.nodes.find(d => {
+            let predicate = d.data._id === entity._id;
+            if (!!d.data.getClusterMemberspecEntity(PREDICATE_MEMBERSPEC)) {
+                predicate |= d.data.getClusterMemberspecEntity(PREDICATE_MEMBERSPEC)._id === entity._id;
+            }
+            return predicate;
+        });
         if (!node) {
             throw new Error('Node for Entity ' + entity._id + ' not found');
         }
@@ -702,19 +708,21 @@ export function D3Blueprint(container) {
             .attr('d', function(d) {
                 let targetNode = nodeForEntity(d.target);
                 let sourceNode = nodeForEntity(d.source);
+                let sourceY = sourceNode.y + (d.source.isMemberSpec() ? _configHolder.nodes.memberspec.circle.cy : 0);
+                let targetY = targetNode.y + (d.target.isMemberSpec() ? _configHolder.nodes.memberspec.circle.cy : 0);
                 let dx = targetNode.x - sourceNode.x;
-                let dy = targetNode.y - sourceNode.y;
+                let dy = targetY - sourceY;
                 let dr = Math.sqrt(dx * dx + dy * dy);
                 let sweep = dx * dy > 0 ? 0 : 1;
-                _mirror.attr('d', `M ${sourceNode.x},${sourceNode.y} A ${dr},${dr} 0 0,${sweep} ${targetNode.x},${targetNode.y}`);
+                _mirror.attr('d', `M ${sourceNode.x},${sourceY} A ${dr},${dr} 0 0,${sweep} ${targetNode.x},${targetY}`);
 
                 let m = _mirror._groups[0][0].getPointAtLength(_mirror._groups[0][0].getTotalLength() - _configHolder.nodes.child.circle.r - 20);
 
                 dx = m.x - sourceNode.x;
-                dy = m.y - sourceNode.y;
+                dy = m.y - sourceY;
                 dr = Math.sqrt(dx * dx + dy * dy);
 
-                return `M ${sourceNode.x},${sourceNode.y} A ${dr},${dr} 0 0,${sweep} ${m.x},${m.y}`;
+                return `M ${sourceNode.x},${sourceY} A ${dr},${dr} 0 0,${sweep} ${m.x},${m.y}`;
             });
         relationData.exit()
             .transition()

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -556,6 +556,7 @@ Entity.prototype.addMetadata = addMetadata;
 Entity.prototype.removeConfig = removeConfig;
 Entity.prototype.removeMetadata = removeMetadata;
 Entity.prototype.isCluster = isCluster;
+Entity.prototype.isMemberSpec = isMemberSpec;
 Entity.prototype.setClusterMemberspecEntity = setClusterMemberspecEntity;
 Entity.prototype.getClusterMemberspecEntity = getClusterMemberspecEntity;
 Entity.prototype.getClusterMemberspecEntities = getClusterMemberspecEntities;
@@ -642,6 +643,14 @@ function isCluster() {
                 'org.apache.brooklyn.entity.group.Fabric']
                 .indexOf(trait) !== -1
     }).length > 0;
+}
+
+/**
+ *
+ * @returns {boolean}
+ */
+function isMemberSpec() {
+    return this.parent.isCluster() && this.parent.getClusterMemberspecEntity() === this;
 }
 
 export function baseType(s) {


### PR DESCRIPTION
As the title say, this expand the relationship support to memberspecs, i.e. if a memberspec has a DSL pointing to any other entity, it will now display an arrow to it.

Here is how it looks like:
<img width="1680" alt="screen shot 2018-10-24 at 19 52 48" src="https://user-images.githubusercontent.com/2082759/47454276-baaa0080-d7c6-11e8-985e-8ec6feaf3da9.png">

And this done with the classic 3 tier webapp blueprint:
```yaml
name: My Web Cluster
services:
  - type: org.apache.brooklyn.entity.database.mysql.MySqlNode
    id: db
    name: My DB (MySQL)
    brooklyn.config:
      datastore.creation.script.url: >-
        https://raw.githubusercontent.com/apache/brooklyn-library/master/examples/simple-web-cluster/src/main/resources/visitors-creation-script.sql
  - type: org.apache.brooklyn.entity.group.DynamicCluster
    name: My Cluster
    id: cluster
    brooklyn.config:
      initialSize: 2
      dynamiccluster.memberspec:
        '$brooklyn:entitySpec':
          type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
          name: Tomcat Server
          brooklyn.config:
            wars.root: >-
              http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.9.0/brooklyn-example-hello-world-sql-webapp-0.9.0.war
            java.sysprops:
              brooklyn.example.db.url: >-
                $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",
                $brooklyn:component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
    brooklyn.enrichers:
      - type: org.apache.brooklyn.enricher.stock.Aggregator
        brooklyn.config:
          enricher.sourceSensor: '$brooklyn:sensor("webapp.reqs.perSec.windowed")'
          enricher.targetSensor: '$brooklyn:sensor("webapp.reqs.perSec.perNode")'
          enricher.aggregating.fromMembers: true
          transformation: average
  - type: org.apache.brooklyn.entity.proxy.nginx.NginxController
    id: nginx
    name: My Load Balancer (nginx)
    brooklyn.config:
      loadbalancer.serverpool: '$brooklyn:entity("cluster")'
      nginx.sticky: false
brooklyn.enrichers:
  - type: org.apache.brooklyn.enricher.stock.Propagator
    brooklyn.config:
      producer: '$brooklyn:entity("nginx")'
      propagating:
        - main.uri
        - main.uri.mapped.subnet
        - main.uri.mapped.public

```

Poke @ahgittin 