### PR TITLE
Composer recent and filters

### DIFF
--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -4,7 +4,7 @@ and widgets cherry-picked as needed.
 
 There are a number of points where UI default choices can be overridden:
 
-* Actions on Composer: by changing the config value for `'actionServiceProvider'` in `ui-modules/blueprint-composer/app/index.js`,
+* Actions on Composer: by changing the config value for `'actionServiceProvider'` from `ui-modules/blueprint-composer/app/index.js`,
   a different set of actions can be displayed on the composer screen
 
 * Composer - Virtual palette items and alternate catalog endpoints:  by registering a different `blueprintServiceProvider`
@@ -19,6 +19,9 @@ There are a number of points where UI default choices can be overridden:
   (as shown in the accompanying `vanillia-with-custom-widget.bom`);
   widgets should be registered as angular directives using the standard Angular naming conventions 
   (e.g. suggestionDropdownDirective), as done for that directive in app/index.js and app/index.less.
+
+* Composer - Identify entities and other items to be preselected when "Recent" is applied by adding a tag of the form
+  `{ ui-composer-recent-preselect: 100 }` (where the number `100` determines its sort order)
 
 <!--
   Licensed to the Apache Software Foundation (ASF) under one

--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.template.html
@@ -16,4 +16,4 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<button class="btn btn-info btn-ouline" ng-click="activateModal()">{{buttonText}}</button>
+<button class="btn btn-info btn-outline" ng-click="activateModal()">{{buttonText}}</button>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector-palette-footer.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector-palette-footer.html
@@ -1,3 +1,21 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <div class="paletteItemsFooter">
     <div ng-if="searchedItems.length === 0" class="no-match">
         <i class="fa fa-lemon-o"></i>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector-palette-footer.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector-palette-footer.html
@@ -1,0 +1,42 @@
+<div class="paletteItemsFooter">
+    <div ng-if="searchedItems.length === 0" class="no-match">
+        <i class="fa fa-lemon-o"></i>
+    </div>
+    <small class="help-block text-sm palette-footer-message">
+        <span ng-if="search">
+          <span ng-if="searchedItems.length === 0">
+            <span ng-if="!skippingFilters && itemsBeforeActiveFilters.length > itemsAfterActiveFilters.length">
+                    <b>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} item{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length > 1 ? 's' : ''}}</b> 
+                    matching search but excluded by filters. 
+                    <button class="btn btn-outline btn-info" ng-click="disableFilters()">Clear filters</button>
+            </span>
+            <span ng-if="skippingFilters || itemsBeforeActiveFilters.length === 0">
+                    No matches for <code>{{ search }}</code>.
+            </span>
+          </span>
+          <span ng-if="searchedItems.length > 0">
+            <span ng-if="skippingFilters">
+                    <b>No matches with selected filters.</b><br/>
+                    Showing matches ignoring filters.
+            </span>
+            <span ng-if="!skippingFilters && itemsBeforeActiveFilters.length > itemsAfterActiveFilters.length">
+                    <b>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} more item{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length > 1 ? 's' : ''}}</b> 
+                    matching search but excluded by filters.
+                    <button class="btn btn-outline btn-info" ng-click="disableFilters()">Clear filters</button>
+            </span>
+          </span>
+        </span>
+        <span ng-if="!search">
+            <span ng-if="skippingFilters && searchedItems.length > 0">
+                    <b>Nothing available in selected filters.</b><br/>
+                    Ignoring filters.
+            </span>
+            <span ng-if="!skippingFilters && itemsBeforeActiveFilters.length > itemsAfterActiveFilters.length">
+                    <b>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} more item{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length > 1 ? 's' : ''}}</b> 
+                    excluded by filters. 
+                    <button class="btn btn-outline btn-info" ng-click="disableFilters()">Clear filters</button>
+            </span>
+        </span>
+        
+    </small>
+</div>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector-palette-footer.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector-palette-footer.html
@@ -17,14 +17,15 @@
   under the License.
 -->
 <div class="paletteItemsFooter">
-    <div ng-if="searchedItems.length === 0" class="no-match">
-        <i class="fa fa-lemon-o"></i>
+    <div ng-if="searchedItems.length === 0" class="icon no-match">
+        <span>&oslash;</span>
     </div>
-    <small class="help-block text-sm palette-footer-message">
+    <small class="help-block text-sm palette-footer-message" ng-class="{ 'no-match': searchedItems.length === 0 }">
         <span ng-if="search">
           <span ng-if="searchedItems.length === 0">
             <span ng-if="!skippingFilters && itemsBeforeActiveFilters.length > itemsAfterActiveFilters.length">
-                    <b>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} item{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length > 1 ? 's' : ''}}</b> 
+                    <strong>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} 
+                        <ng-pluralize count="itemsBeforeActiveFilters.length" when="{ '1': 'item', 'other': 'items' }"></<ng-pluralize></strong> 
                     matching search but excluded by filters. 
                     <button class="btn btn-outline btn-info" ng-click="disableFilters()">Clear filters</button>
             </span>
@@ -34,23 +35,28 @@
           </span>
           <span ng-if="searchedItems.length > 0">
             <span ng-if="skippingFilters">
-                    <b>No matches with selected filters.</b><br/>
+                    <strong>No matches with selected filters.</strong><br/>
                     Showing matches ignoring filters.
             </span>
             <span ng-if="!skippingFilters && itemsBeforeActiveFilters.length > itemsAfterActiveFilters.length">
-                    <b>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} more item{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length > 1 ? 's' : ''}}</b> 
+                    <strong>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} more 
+                        <ng-pluralize count="itemsBeforeActiveFilters.length" when="{ '1': 'item', 'other': 'items' }"></<ng-pluralize></strong> 
                     matching search but excluded by filters.
                     <button class="btn btn-outline btn-info" ng-click="disableFilters()">Clear filters</button>
             </span>
           </span>
         </span>
         <span ng-if="!search">
+            <span ng-if="itemsBeforeActiveFilters.length == 0">
+                <strong>Nothing available.</strong>
+            </span>
             <span ng-if="skippingFilters && searchedItems.length > 0">
-                    <b>Nothing available in selected filters.</b><br/>
+                    <strong>Nothing available in selected filters.</strong><br/>
                     Ignoring filters.
             </span>
             <span ng-if="!skippingFilters && itemsBeforeActiveFilters.length > itemsAfterActiveFilters.length">
-                    <b>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} more item{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length > 1 ? 's' : ''}}</b> 
+                    <strong>{{ itemsBeforeActiveFilters.length - itemsAfterActiveFilters.length }} more 
+                        <ng-pluralize count="itemsBeforeActiveFilters.length" when="{ '1': 'item', 'other': 'items' }"></<ng-pluralize></strong> 
                     excluded by filters. 
                     <button class="btn btn-outline btn-info" ng-click="disableFilters()">Clear filters</button>
             </span>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -39,6 +39,7 @@ export function catalogSelectorDirective() {
             onSelect: '&',
             rowsPerPage: '<',  // if unset then fill
             reservedKeys: '<?',
+            state: '<?',
             mode: '@?',  // for use by downstream projects to pass in special modes
         },
         template: template,
@@ -147,15 +148,15 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
     this.$timeout = $timeout;
 
     $scope.viewModes = PALETTE_VIEW_MODES;
-    $scope.state = {
-        orders: ['name', 'type', 'id'],
-        currentOrder: 'name',
-        viewMode: PALETTE_VIEW_MODES.normal,
-    };
+    $scope.viewOrders = ['name', 'type', 'id'];
+    
+    if (!$scope.state) $scope.state = {};
+    if (!$scope.state.viewMode) $scope.state.viewMode = PALETTE_VIEW_MODES.normal;
+    if (!$scope.state.currentOrder) $scope.state.currentOrder = 'name';
     
     $scope.pagination = {
         page: 1,
-        itemsPerPage: $scope.state.viewMode.itemsPerRow * ($scope.rowsPerPage || MIN_ROWS_PER_PAGE)
+        itemsPerPage: $scope.state.viewMode.itemsPerRow * ($scope.rowsPerPage || 1)  // will fill out after load
     };
     
     $scope.getEntityNameForPalette = function(item, entityName) {

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -19,6 +19,7 @@
 import angular from 'angular';
 import {EntityFamily} from '../util/model/entity.model';
 import template from './catalog-selector.template.html';
+import footerTemplate from './catalog-selector-palette-footer.html';
 import moment from "moment";
 
 const MIN_ROWS_PER_PAGE = 4;
@@ -281,7 +282,10 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
                 return $scope.recentItems; 
             }, enabled: false },
     ];
-    $scope.disableFilters = () => $scope.filters.forEach( f => f.enabled = false );
+    $scope.disableFilters = (showFilters) => {
+        $scope.filters.forEach( f => f.enabled = false );
+        if (showFilters !== false) $scope.showPaletteControls = true;
+    }
     
     // this can be overridden for palette sections/modes which show a subset of the types returned by the server;
     // this is applied when the data is received from the server.
@@ -321,8 +325,8 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
     $scope.customSubHeadTemplateName = 'composer-palette-empty-sub-head';
     $templateCache.put($scope.customSubHeadTemplateName, '');
     
-    $scope.customFooterTemplateName = 'composer-palette-empty-footer';
-    $templateCache.put($scope.customFooterTemplateName, '');
+    $scope.customFooterTemplateName = 'composer-palette-default-footer';
+    $templateCache.put($scope.customFooterTemplateName, footerTemplate);
 
     // allow downstream to configure this controller and/or scope
     (composerOverrides.configurePaletteController || function() {})(this, $scope, $element);

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -20,7 +20,7 @@ import angular from 'angular';
 import {EntityFamily} from '../util/model/entity.model';
 import template from './catalog-selector.template.html';
 import footerTemplate from './catalog-selector-palette-footer.html';
-import moment from "moment";
+import { distanceInWordsToNow } from 'date-fns';
 
 const MIN_ROWS_PER_PAGE = 4;
 
@@ -252,7 +252,7 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
         let l = (Number)(item.lastUsed);
         if (!l || isNaN(l) || l<=0) return "";
         if (l < 100000) return 'Preselected for inclusion in "Recent" filter.';
-        return 'Last used: ' + moment(l).fromNow();
+        return 'Last used: ' + distanceInWordsToNow(l, { includeSeconds: true, addSuffix: true });
     }; 
     $scope.showPaletteControls = false;
     $scope.onFiltersShown = () => {

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -70,7 +70,7 @@ function repaginate($scope, $element) {
         }
         let header = angular.element(main[0].querySelector(".catalog-palette-header"));
         let footer = angular.element(main[0].querySelector(".catalog-palette-footer"));
-        rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor( (main[0].offsetHeight - header[0].offsetHeight - footer[0].offsetHeight) / ($scope.state.viewMode.rowHeightPx || 96)) );
+        rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor( (main[0].offsetHeight - header[0].offsetHeight - footer[0].offsetHeight - 16) / ($scope.state.viewMode.rowHeightPx || 96)) );
     }
     $scope.$apply( () => $scope.pagination.itemsPerPage = rowsPerPage * $scope.state.viewMode.itemsPerRow );
 }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -177,7 +177,7 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
             symbolicName: $scope.search,
             name: $scope.search,
             displayName: $scope.search,
-            supertypes: [$scope.family.superType]
+            supertypes: ($scope.family ? [ $scope.family.superType ] : []),
         };
     });
 

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -259,7 +259,7 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
       $timeout( () => {
         // check do we need to show the multiline
         let filters = angular.element($element[0].querySelector(".filters"));
-        $scope.$apply( () => $scope.filterSettings.filtersMultilineAvailable = filters[0].scrollHeight > filters[0].offsetHeight );
+        $scope.$apply( () => $scope.filterSettings.filtersMultilineAvailable = filters[0].scrollHeight > filters[0].offsetHeight + 6 );
         
         repaginate($scope, $element);
       } );

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -47,7 +47,7 @@ export function catalogSelectorDirective() {
         scope: {
             family: '<',
             onSelect: '&',
-            rowsPerPage: '<',  // if unset then fill
+            rowsPerPage: '<?',  // if unset then fill
             reservedKeys: '<?',
             state: '<?',
             mode: '@?',  // for use by downstream projects to pass in special modes
@@ -74,7 +74,7 @@ function repaginate($scope, $element) {
     if (!rowsPerPage) {
         let main = angular.element($element[0].querySelector(".catalog-palette-main"));
         if (!main || main[0].offsetHeight==0) {
-            // console.log("no main or hidden or items per page fixed");
+            // no main, or hidden, or items per page fixed
             return;
         }
         let header = angular.element(main[0].querySelector(".catalog-palette-header"));

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -57,7 +57,6 @@ function link($scope, $element, attrs, controller) {
         (values) => controller.$timeout( () => repaginate($scope, $element) ) );
     // also repaginate on window resize    
     angular.element(window).bind('resize', () => repaginate($scope, $element));
-
 }
 
 function repaginate($scope, $element) {
@@ -272,6 +271,32 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
         });
         $scope.items = items;
     });
+    $scope.showPaletteControls = false;
+    $scope.onFiltersShown = () => {
+      $timeout( () => {
+        // check do we need to show the multiline
+        let filters = angular.element($element[0].querySelector(".filters"));
+        $scope.$apply( () => $scope.filterSettings.filtersMultilineAvailable = filters[0].scrollHeight > filters[0].offsetHeight );
+        
+        repaginate($scope, $element);
+      } );
+    };
+    $scope.togglePaletteControls = () => {
+        $scope.showPaletteControls = !$scope.showPaletteControls;
+        $timeout( () => repaginate($scope, $element) );
+    }
+    $scope.toggleShowAllFilters = () => {
+        $scope.filterSettings.showAllFilters = !$scope.filterSettings.showAllFilters;
+        $timeout( () => repaginate($scope, $element) );
+    };
+    $scope.filterSettings = {};
+
+    $scope.filters = [
+        // TODO determine recent ones, set some default recent ones
+        { label: 'Recent', icon: 'clock-o', title: "Recently used and standard favorites", filterFn: item => item.displayTags.includes("RECENT"), enabled: false },
+    ];
+    $scope.disableFilters = () => $scope.filters.forEach( f => f.enabled = false );
+    
     // this can be overridden for third-party filters.
     // it receives result of filtering based on search so filters can adjust based on number of search resullts
     $scope.filterPaletteItems = (items) => items;
@@ -286,5 +311,4 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
     // allow downstream to configure this controller and/or scope
     (composerOverrides.configurePaletteController || function() {})(this, $scope, $element);
     
-    $scope.paletteItemClasses = "col-xs-3";
 }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -64,7 +64,7 @@ function repaginate($scope, $element) {
     let header = angular.element(main[0].querySelector(".catalog-palette-header"));
     let footer = angular.element(main[0].querySelector(".catalog-palette-footer"));
     $scope.$apply( () =>
-        $scope.pagination.itemsPerPage = Math.max(MIN_ITEMS_PER_PAGE, Math.floor( (main[0].offsetHeight - header[0].offsetHeight - footer[0].offsetHeight - 4) / 96) * 4) );
+        $scope.pagination.itemsPerPage = Math.max(MIN_ITEMS_PER_PAGE, Math.floor( (main[0].offsetHeight - header[0].offsetHeight - footer[0].offsetHeight) / 96) * 4) );
 }
 
 export function catalogSelectorSearchFilter() {

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -207,6 +207,30 @@ catalog-selector {
       }
     }
   }
+  .catalog-palette-footer {
+    .palette-footer-message {
+        .btn {
+          font-size: inherit;
+          padding: 3px 8px;
+          margin-left: 1em;
+          font-style: normal;
+        }
+        text-align: right;
+        // useful if it wraps, e.g. because pagination buttons show:
+        line-height: 2;
+        margin-top: -2px;
+    }
+    div[uib-pagination] {
+      margin-left: 1em;
+    }
+    .no-match {
+      font-size: 8em;
+      margin-top: 24px;
+      margin-bottom: 36px;
+      text-align: center;
+      color: @gray-lighter;
+    }
+  }
 }
 
 .catalog-selector-popover {

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -22,7 +22,8 @@ catalog-selector {
   
   display: block;
   margin-top: 15px;
-
+  height: 100%;
+  
   .grid {
     margin-bottom: 15px;
   }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -230,12 +230,16 @@ catalog-selector {
         .type-symbolic-name {
             font-weight: bold;
         }
+        i { height: 100%; }
       }
       .mini-icon {
         width: 1.5em;
         overflow-x: visible;
-        margin-left: -1.5em;
+        margin-left: -1.75em;
         text-align: center;
+      }
+      .label {
+        line-height: 2.2;
       }
     }
     .deprecated-marker {

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -42,6 +42,36 @@ catalog-selector {
     padding-left: 5px;
     padding-right: 5px;
     height: 96px;
+    &.item-compact {
+        height: 75px;
+    }
+    
+    &.item-full-width {
+        .item {
+            display: flex;
+            flex-direction: horizontal;
+            .item-logo {
+                flex: 0 0 auto;
+                width: auto;
+                height: 78px;
+                min-width: 90px;
+                img {
+                    margin: 0;
+                    width: auto;
+                }
+            }
+            .item-content {
+                flex: 1 1 auto;
+                display: flex;
+                align-items: center;
+                h3 {
+                    text-align: left;
+                    font-size: 1em;
+                    margin-left: 8px;
+                }
+            }
+        }
+    }
   }
   .catalog-palette-footer {
     padding-bottom: 5px;
@@ -64,7 +94,6 @@ catalog-selector {
       margin-bottom: -2px;
       padding-top: 3px;
       padding-bottom: 7px;
-      // transform: scaleY(1.1);
 
       .fa-info-circle {
         opacity: 1;
@@ -110,7 +139,7 @@ catalog-selector {
         left: 0;
         right: 0;
         margin: auto;
-        max-width: 90%;
+        max-width: 100%;
         max-height: 100%;
       }
     }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -26,6 +26,8 @@ catalog-selector {
   
   .grid {
     margin-bottom: 15px;
+    padding-left: 10px;
+    padding-right: 10px;
   }
   .pagination {
     margin-top: 0;
@@ -39,6 +41,10 @@ catalog-selector {
   .catalog-palette-item {
     padding-left: 5px;
     padding-right: 5px;
+    height: 96px;
+  }
+  .catalog-palette-footer {
+    padding-bottom: 5px;
   }
   
   .item {
@@ -48,10 +54,17 @@ catalog-selector {
     transition: all @duration-item ease;
     position: relative;
     background: white; //useful when dragging
-    box-shadow: 0 0 rgba(0, 0, 0, 0.1), 0 1px 2px 1px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 rgba(0, 0, 0, 0.1), 0 0 2px 1px rgba(0, 0, 0, 0.2);
     &:hover {
-      box-shadow: 0 0 rgba(0, 0, 0, 0.2), 0 2px 4px 1px rgba(0, 0, 0, 0.2);
-      transform: scale(1.1);
+      box-shadow: 0 0 rgba(0, 0, 0, 0.2), 0 0 4px 1px rgba(0, 0, 0, 0.5);
+      margin: -2px;
+      padding: 5px;
+      
+      margin-top: 7px;
+      margin-bottom: -2px;
+      padding-top: 3px;
+      padding-bottom: 7px;
+      // transform: scaleY(1.1);
 
       .fa-info-circle {
         opacity: 1;
@@ -61,9 +74,10 @@ catalog-selector {
         position: absolute;
         top: 0;
         left: 0;
+        margin: 0;
+        border: 3px solid @brand-primary;
         width: 100%;
         height: 100%;
-        transform: scale(1.15);
     }
 
     .fa-info-circle {

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -166,10 +166,6 @@ catalog-selector {
       margin-top: 3px;
       margin-bottom: 3px;
   }
-  .no-match {
-    margin-top: 12px;
-    font-style: italic;
-  }
   
   .spinner-area {
     height: 300px;
@@ -224,10 +220,13 @@ catalog-selector {
       margin-left: 1em;
     }
     .no-match {
+      text-align: center;
+      font-size: 120%;
+    }
+    .no-match.icon {
       font-size: 8em;
       margin-top: 24px;
-      margin-bottom: 36px;
-      text-align: center;
+      margin-bottom: 6px;
       color: @gray-lighter;
     }
   }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -16,7 +16,7 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<div class="container-fluid">
+<div class="container-fluid palette-full-height-wrapper">
     <div ng-show="isLoading">
         <div class="spinner-area">
             <div class="spinner">
@@ -30,7 +30,8 @@
         </div>
     </div>
 
-    <div ng-show="!isLoading">
+    <div ng-show="!isLoading" class="catalog-palette-main palette-full-height-wrapper">
+      <div class="catalog-palette-header">
         <div class="form-group" ng-class="{'has-error': isReserved()}">
             <div class="input-group input-group-sm">
                 <span class="input-group-btn" uib-dropdown keyboard-nav>
@@ -56,8 +57,9 @@
         <small class="help-block text-sm no-match" ng-if="search && searchedItems.length === 0">
             No {{family.displayName.toLowerCase()}} matching the current search
         </small>
+      </div>
 
-        <div class="row grid catalog-palette">
+        <div class="row grid">
             <!-- here and below, col-xs-3 or -4 or -2 all work giving different densities;
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
             <div class="col-xs-3 catalog-palette-item"
@@ -94,9 +96,10 @@
             </div>
         </div>
 
-        <div uib-pagination total-items="searchedItems.length" items-per-page="pagination.itemsPerPage" ng-model="pagination.page" boundary-link-numbers="true" rotate="false" max-size="4" ng-show="searchedItems.length > pagination.itemsPerPage" class="pagination-sm pull-right"></div>
-        
-        <ng-include src="customFooterTemplateName"/>
+        <div class="catalog-palette-footer">
+            <div uib-pagination total-items="searchedItems.length" items-per-page="pagination.itemsPerPage" ng-model="pagination.page" boundary-link-numbers="true" rotate="false" max-size="4" ng-show="searchedItems.length > pagination.itemsPerPage" class="pagination-sm pull-right"></div>
+            <ng-include src="customFooterTemplateName"/>
+        </div>
     </div>
 </div>
 

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -103,7 +103,7 @@
             <!-- here and below, col-xs-3 or -4 or -2 all work giving different densities;
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
             <div class="catalog-palette-item" ng-class="state.viewMode.classes"
-                    ng-repeat="item in searchedItems = filterPaletteItems(items | catalogSelectorSearch:search) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
+                    ng-repeat="item in searchedItems = filterPaletteItemsWithActiveFilters(items | catalogSelectorSearch:search) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
                     ng-click="onSelectItem(item)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(item, $event)" ng-dragend="onDragEnd(item, $event)">
                     <div class="item-logo">
@@ -155,8 +155,10 @@
         </div>
         <p class="quick-info-description" ng-if="item.description">{{item.description}}</p>
         <div class="quick-info-metadata bundle">
+            <p ng-if="lastUsedText(item)"><i class="mini-icon fa fa-clock-o"></i> {{ lastUsedText(item) }}</p>
             <p ng-if="item.displayTags && item.displayTags.length"><i class="mini-icon fa fa-fw fa-tags"></i> 
-                <span ng-repeat="tag in item.displayTags" class="label label-primary palette-item-tag">{{ tag }}</span> </p>
+                <span ng-repeat-start="tag in item.displayTags" class="label label-primary palette-item-tag">{{ tag }}</span>
+                <span ng-repeat-end> </span> </p>
             <p><i class="mini-icon fa fa-fw fa-file-zip-o"></i> {{item.containingBundle}}</p>
         </div>
     </div>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -46,7 +46,7 @@
                         </li>
                         
                         <li role="menuitem" class="dropdown-header">Sort</li>
-                        <li role="menuitem" ng-repeat="order in state.orders track by $index" ng-class="{'active': state.currentOrder === order}" class="layer">
+                        <li role="menuitem" ng-repeat="order in viewOrders track by $index" ng-class="{'active': state.currentOrder === order}" class="layer">
                             <a ng-click="state.currentOrder = order"><i class="fa fa-fw fa-circle"></i> {{order | capitalize}}</a>
                         </li>
                     </ul>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -100,7 +100,7 @@
             <!-- here and below, col-xs-3 or -4 or -2 all work giving different densities;
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
             <div class="catalog-palette-item" ng-class="state.viewMode.classes"
-                    ng-repeat="item in searchedItems = filterPaletteItemsWithActiveFilters(items | catalogSelectorSearch:search) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
+                    ng-repeat="item in searchedItems = (items | catalogSelectorSearch:search | catalogSelectorFilters:this) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
                     ng-click="onSelectItem(item)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(item, $event)" ng-dragend="onDragEnd(item, $event)">
                     <div class="item-logo">

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -40,7 +40,12 @@
                     </button>
                     {{filters | json}}
                     <ul class="dropdown-menu" role="menu" uib-dropdown-menu>
-                        <li role="menuitem" class="dropdown-header">Order by</li>
+                        <li role="menuitem" class="dropdown-header">View</li>
+                        <li role="menuitem" ng-repeat="view in viewModes track by $index" ng-class="{'active': state.viewMode === view}" class="layer">
+                            <a ng-click="state.viewMode = view"><i class="fa fa-fw fa-circle"></i> {{view.name}}</a>
+                        </li>
+                        
+                        <li role="menuitem" class="dropdown-header">Sort</li>
                         <li role="menuitem" ng-repeat="order in state.orders track by $index" ng-class="{'active': state.currentOrder === order}" class="layer">
                             <a ng-click="state.currentOrder = order"><i class="fa fa-fw fa-circle"></i> {{order | capitalize}}</a>
                         </li>
@@ -62,14 +67,14 @@
         <div class="row grid">
             <!-- here and below, col-xs-3 or -4 or -2 all work giving different densities;
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
-            <div class="col-xs-3 catalog-palette-item"
+            <div class="catalog-palette-item" ng-class="state.viewMode.classes"
                     ng-repeat="item in searchedItems = (filterPaletteItems(items | catalogSelectorSearch:search) | catalogSelectorSort:family) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
                     ng-click="onSelectItem(item)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(item, $event)" ng-dragend="onDragEnd(item, $event)">
                     <div class="item-logo">
                         <img ng-src="{{item | iconGeneratorPipe:'symbolicName'}}" alt="{{item.displayName}} logo" on-error="onImageError" item-id="{{item.symbolicName}}"/>
                     </div>
-                    <div class="item-content" ng-class="{ deprecated: item.deprecated }">
+                    <div class="item-content" ng-class="{ deprecated: item.deprecated }" ng-hide="state.viewMode.hideName">
                         <h3>{{ getEntityNameForPalette(item, item | entityName) }}</h3>
                     </div>
                     <i class="fa fa-info-circle"
@@ -81,12 +86,14 @@
                 </div>
             </div>
 
-            <div class="col-xs-3 catalog-palette-item" ng-if="searchedItems.length === 0 && search && allowFreeForm()" ng-click="onSelectItem(freeFormTile)">
+            <div class="catalog-palette-item"
+                    ng-class="state.viewMode.classes" 
+                    ng-if="searchedItems.length === 0 && search && allowFreeForm()" ng-click="onSelectItem(freeFormTile)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(freeFormTile, $event)" ng-dragend="onDragEnd(freeFormTile, $event)">
                     <div class="item-logo">
                         <img ng-src="{{freeFormTile | iconGeneratorPipe:'symbolicName'}}" alt="{{freeFormTile.displayName}} logo" on-error="onImageError" item-id="{{freeFormTile.symbolicName}}"/>
                     </div>
-                    <div class="item-content">
+                    <div class="item-content" ng-hide="state.viewMode.hideName">
                         <h3>{{freeFormTile | entityName}}</h3>
                     </div>
                 </div>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -94,9 +94,6 @@
             </div>
             <ng-include src="customSubHeadTemplateName"/>
         </div>
-        <small class="help-block text-sm no-match" ng-if="search && searchedItems.length === 0">
-            No {{family.displayName.toLowerCase()}} matching the current search
-        </small>
       </div>
 
         <div class="row grid">

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -34,28 +34,63 @@
       <div class="catalog-palette-header">
         <div class="form-group" ng-class="{'has-error': isReserved()}">
             <div class="input-group input-group-sm">
-                <span class="input-group-btn" uib-dropdown keyboard-nav>
-                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" uib-dropdown-toggle>
-                        <i class="fa fa-sort"></i>
+                <span class="input-group-btn" keyboard-nav>
+                    <button id="palette-controls-button" type="button" class="btn btn-default dropdown-toggle" ng-class="{ 'btn-primary': showPaletteControls }" id="palette-controls" aria-haspopup="true" aria-expanded="false" 
+                            ng-click="togglePaletteControls()">
+                        <i class="fa fa-cog"></i>
                     </button>
-                    {{filters | json}}
-                    <ul class="dropdown-menu" role="menu" uib-dropdown-menu>
-                        <li role="menuitem" class="dropdown-header">View</li>
-                        <li role="menuitem" ng-repeat="view in viewModes track by $index" ng-class="{'active': state.viewMode === view}" class="layer">
-                            <a ng-click="state.viewMode = view"><i class="fa fa-fw fa-circle"></i> {{view.name}}</a>
-                        </li>
-                        
-                        <li role="menuitem" class="dropdown-header">Sort</li>
-                        <li role="menuitem" ng-repeat="order in viewOrders track by $index" ng-class="{'active': state.currentOrder === order}" class="layer">
-                            <a ng-click="state.currentOrder = order"><i class="fa fa-fw fa-circle"></i> {{order | capitalize}}</a>
-                        </li>
-                    </ul>
                 </span>
                 <input ng-model="search" type="text" placeholder="{{getPlaceHolder()}}" class="form-control" auto-focus />
                 <span class="input-group-addon">
                     <strong>{{searchedItems.length === 0 && search && allowFreeForm() ? 1 : searchedItems.length}}</strong>
                     {{(searchedItems.length === 0 && search && allowFreeForm() ? 1 : searchedItems.length) == 1 ? 'item' : 'items'}}
                 </span>
+            </div>
+            <div class="pane-nav-row" id="palette-controls" ng-if="showPaletteControls" aria-labelledby="palette-controls-button">
+
+             <div class="filters" ng-class="{ 'multiline': filterSettings.showAllFilters }" ng-init="onFiltersShown()">
+             
+              <div class="spacer" ng-repeat-start="filter in filters" ng-if="filter.spacerBefore"></div>
+              <div class="nav-row-item" ng-repeat-end ng-click="filter.enabled = !filter.enabled">
+                <span title="{{ filter.hoverTest }}" class="label" ng-class="{'label-primary': filter.enabled, 'label-default': !filter.enabled }">
+                    <i class="fa fa-{{ filter.icon }}" ng-if="filter.icon"></i>
+                    <span ng-if="filter.label">{{ filter.label }}</span>
+                </span>
+              </div>
+             </div>
+
+              <div class="nav-row-item" ng-if="filterSettings.filtersMultilineAvailable" title="More filters available"
+                    ng-click="toggleShowAllFilters()" >
+                <span class="label" ng-class="{'label-primary': filterSettings.showAllFilters, 'label-default': !filterSettings.showAllFilters }">
+                    ...
+                </span>
+              </div>
+              
+              <div class="spacer"></div>
+                
+              <span uib-dropdown>
+                <a href id="palette-sort" uib-dropdown-toggle aria-haspopup="true" aria-expanded="false" >
+                  <div class="nav-row-item tool" title="Sort">
+                    <i class="fa fa-sort"></i></div>
+                </a>
+                <ul class="dropdown-menu right-align-icon" role="menu" uib-dropdown-menu aria-labelledby="palette-sort">
+                        <li role="menuitem" ng-repeat="order in viewOrders track by $index" ng-class="{'active': state.currentOrder === order}" class="layer">
+                            <a ng-click="state.currentOrder = order"><i class="fa fa-fw fa-circle"></i> {{order | capitalize}}</a>
+                        </li>
+                </ul>
+              </span>
+              
+              <span uib-dropdown>
+                <a href id="palette-view-mode" uib-dropdown-toggle aria-haspopup="true" aria-expanded="false" >
+                  <div class="nav-row-item tool" title="Display mode">
+                    <i class="fa fa-th"></i></div>
+                </a>
+                <ul class="dropdown-menu right-align-icon" role="menu" uib-dropdown-menu aria-labelledby="palette-view-mode">
+                        <li role="menuitem" ng-repeat="view in viewModes track by $index" ng-class="{'active': state.viewMode === view}" class="layer">
+                            <a ng-click="state.viewMode = view"><i class="fa fa-fw fa-circle"></i> {{view.name}}</a>
+                        </li>
+                </ul>
+              </span>
             </div>
             <ng-include src="customSubHeadTemplateName"/>
         </div>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -74,8 +74,8 @@
                     <i class="fa fa-sort"></i></div>
                 </a>
                 <ul class="dropdown-menu right-align-icon" role="menu" uib-dropdown-menu aria-labelledby="palette-sort">
-                        <li role="menuitem" ng-repeat="order in viewOrders track by $index" ng-class="{'active': state.currentOrder === order}" class="layer">
-                            <a ng-click="state.currentOrder = order"><i class="fa fa-fw fa-circle"></i> {{order | capitalize}}</a>
+                        <li role="menuitem" ng-repeat="order in viewOrders track by $index" ng-class="{'active': state.currentOrder[0] === order.field}" class="layer">
+                            <a ng-click="sortBy(order)"><i class="fa fa-fw fa-circle"></i> {{ order.label }}</a>
                         </li>
                 </ul>
               </span>
@@ -103,7 +103,7 @@
             <!-- here and below, col-xs-3 or -4 or -2 all work giving different densities;
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
             <div class="catalog-palette-item" ng-class="state.viewMode.classes"
-                    ng-repeat="item in searchedItems = (filterPaletteItems(items | catalogSelectorSearch:search) | catalogSelectorSort:family) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
+                    ng-repeat="item in searchedItems = filterPaletteItems(items | catalogSelectorSearch:search) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
                     ng-click="onSelectItem(item)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(item, $event)" ng-dragend="onDragEnd(item, $event)">
                     <div class="item-logo">

--- a/ui-modules/blueprint-composer/app/components/providers/palette-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/palette-service.provider.js
@@ -37,7 +37,9 @@ export function paletteServiceProvider() {
             sections[id] = section;
         },
         deleteSection(id) {
+            let old = sections[id];
             delete sections[id];
+            return old;
         }
     }
 }

--- a/ui-modules/blueprint-composer/app/components/providers/palette-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/palette-service.provider.js
@@ -48,6 +48,7 @@ class PaletteService {
     constructor(sectionsToAdd) {
         this.sections = {};
         this.requiredFields = ['title', 'type', 'icon'];
+        // 'mode' is optional
 
         for (const [id, section] of Object.entries(sectionsToAdd)) {
             this.addSection(id, section);

--- a/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
@@ -58,7 +58,5 @@ function RecentlyUsedService($log) {
         item.lastUsed = service.getLastUsed(item);
     };
     
-    service.markUsed('io.cloudsoft.demo.bank.threetier:0.1.0-SNAPSHOT::db:0.1.0-SNAPSHOT', 100);
-    
     return service;
 }

--- a/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export function recentlyUsedServiceProvider() {
+    return {
+        $get: ['$log', function ($log) { return new RecentlyUsedService($log); }]
+    }
+}
+
+export const PREFIX = 'org.apache.brooklyn.composer.lastUsed:';
+
+function RecentlyUsedService($log) {
+    let service = {};
+    
+    service.getId = (brooklynObject) => {
+        if (typeof brooklynObject === 'string') return brooklynObject;
+        return (brooklynObject.containingBundle || '?') + "::" + 
+            (brooklynObject.symbolicName || '?') + ":" + (brooklynObject.version || '?');
+    };
+    
+    service.markUsed = (item, when) => {
+        let id = service.getId(item);
+        if (when) {
+            let old = service.getLastUsed(id);
+            if (old > when) return;
+        } else {
+            when = Date.now();
+        }
+        sessionStorage.setItem(PREFIX+id, when);
+        if (item.lastUsed) item.lastUsed = when;
+    };
+    service.getLastUsed = (item) => {
+        let id = service.getId(item); 
+        let s = sessionStorage.getItem(PREFIX+id); 
+        return s ? ((Number)(s)) : -1; 
+    };
+    
+    service.embellish = (item) => {
+        item.lastUsed = service.getLastUsed(service.getId(item));
+    };
+    
+    service.markUsed('io.cloudsoft.demo.bank.threetier:0.1.0-SNAPSHOT::db:0.1.0-SNAPSHOT', 100);
+    
+    return service;
+}

--- a/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
@@ -43,6 +43,7 @@ function RecentlyUsedService($log) {
             when = Date.now();
         }
         sessionStorage.setItem(PREFIX+id, when);
+        // update the item if it is embellished
         if (item.lastUsed) item.lastUsed = when;
     };
     service.getLastUsed = (item) => {

--- a/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/recently-used-service.provider.js
@@ -47,12 +47,15 @@ function RecentlyUsedService($log) {
     };
     service.getLastUsed = (item) => {
         let id = service.getId(item); 
-        let s = sessionStorage.getItem(PREFIX+id); 
-        return s ? ((Number)(s)) : -1; 
+        let s = sessionStorage.getItem(PREFIX+id);
+        if (s) return ((Number)(s));
+        let tag = item.tags && item.tags.find(t => t['ui-composer-recent-preselect']);
+        if (tag) return tag['ui-composer-recent-preselect']; 
+        return -1; 
     };
     
     service.embellish = (item) => {
-        item.lastUsed = service.getLastUsed(service.getId(item));
+        item.lastUsed = service.getLastUsed(item);
     };
     
     service.markUsed('io.cloudsoft.demo.bank.threetier:0.1.0-SNAPSHOT::db:0.1.0-SNAPSHOT', 100);

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -130,7 +130,7 @@ function composerOverridesProvider() {
 }
 
 function actionConfig(actionServiceProvider) {
-    actionServiceProvider.addAction("deploy", {html: '<button class="btn btn-ouline btn-success" ng-click="vm.deployApplication()" ng-disabled="vm.deploying">Deploy</button>'});
+    actionServiceProvider.addAction("deploy", {html: '<button class="btn btn-outline btn-success" ng-click="vm.deployApplication()" ng-disabled="vm.deploying">Deploy</button>'});
     actionServiceProvider.addAction("add", {html: '<catalog-saver config="vm.saveToCatalogConfig"></catalog-saver>'});
 }
 

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -46,6 +46,7 @@ import {designerDirective} from "./components/designer/designer.directive";
 import {
     catalogSelectorDirective,
     catalogSelectorSearchFilter,
+    catalogSelectorFiltersFilter,
 } from "./components/catalog-selector/catalog-selector.directive";
 import customActionDirective from "./components/custom-action/custom-action.directive";
 import customConfigSuggestionDropdown from "./components/custom-config-widget/suggestion-dropdown";
@@ -95,6 +96,7 @@ angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 
     .filter('entityTypes', entityTypesFilter)
     .filter('locations', locationsFilter)
     .filter('catalogSelectorSearch', catalogSelectorSearchFilter)
+    .filter('catalogSelectorFilters', catalogSelectorFiltersFilter)
     .filter('dslParamLabel', ['$filter', dslParamLabelFilter])
     .config(['$urlRouterProvider', '$stateProvider', '$logProvider', applicationConfig])
     .config(['actionServiceProvider', actionConfig])

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -46,7 +46,6 @@ import {designerDirective} from "./components/designer/designer.directive";
 import {
     catalogSelectorDirective,
     catalogSelectorSearchFilter,
-    catalogSelectorSortFilter
 } from "./components/catalog-selector/catalog-selector.directive";
 import customActionDirective from "./components/custom-action/custom-action.directive";
 import customConfigSuggestionDropdown from "./components/custom-config-widget/suggestion-dropdown";
@@ -57,6 +56,7 @@ import {objectCacheFactory} from './components/factories/object-cache.factory';
 import {entityNameFilter, entityVersionFilter, entityTypesFilter} from "./components/filters/entity.filter";
 import {locationsFilter} from "./components/filters/locations.filter";
 import {blueprintServiceProvider} from "./components/providers/blueprint-service.provider";
+import {recentlyUsedServiceProvider} from "./components/providers/recently-used-service.provider";
 import {dslServiceProvider} from "./components/providers/dsl-service.provider";
 import {paletteDragAndDropServiceProvider} from "./components/providers/palette-dragndrop.provider";
 import {actionServiceProvider} from "./components/providers/action-service.provider";
@@ -83,6 +83,7 @@ angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 
     .directive('catalogSelector', catalogSelectorDirective)
     .directive('breadcrumbs', breadcrumbsDirective)
     .provider('blueprintService', blueprintServiceProvider)
+    .provider('recentlyUsedService', recentlyUsedServiceProvider)
     .provider('dslService', dslServiceProvider)
     .provider('paletteDragAndDropService', paletteDragAndDropServiceProvider)
     .provider('actionService', actionServiceProvider)
@@ -94,7 +95,6 @@ angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 
     .filter('entityTypes', entityTypesFilter)
     .filter('locations', locationsFilter)
     .filter('catalogSelectorSearch', catalogSelectorSearchFilter)
-    .filter('catalogSelectorSort', ['$filter', catalogSelectorSortFilter])
     .filter('dslParamLabel', ['$filter', dslParamLabelFilter])
     .config(['$urlRouterProvider', '$stateProvider', '$logProvider', applicationConfig])
     .config(['actionServiceProvider', actionConfig])

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
@@ -16,11 +16,13 @@
   specific language governing permissions and limitations
   under the License.
 -->
+<div class="add-panel">
+
 <section class="spec-parent">
     <a ng-href="{{getParentLink()}}">{{getParentLinkLabel()}}</a>
 </section>
 
-<div class="layout">
+ <div class="add-panel-main">
     <div class="toolbar">
         <div class="list-group">
             <a href class="list-group-item"
@@ -33,10 +35,7 @@
         </div>
     </div>
 
-    <designer></designer>
-</div>
-
-<div class="pane pane-palette" ng-if="vm.selectedSection">
+  <div class="pane pane-palette" ng-if="vm.selectedSection">
     <div ng-repeat="section in vm.sections track by $index"
          class="palette-full-height-wrapper"
          ng-if="vm.selectedSection === section">
@@ -46,6 +45,9 @@
                 <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
-        <catalog-selector state="paletteState" family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
+        <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
     </div>
+  </div>
+ </div>
+
 </div>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
@@ -20,8 +20,32 @@
     <a ng-href="{{getParentLink()}}">{{getParentLinkLabel()}}</a>
 </section>
 
-<div class="panel-group"><div class="panel"><div class="panel-body">
+<div class="layout">
+    <div class="toolbar">
+        <div class="list-group">
+            <a href class="list-group-item"
+               ng-repeat="section in vm.sections track by $index"
+               ng-class="{'active': vm.selectedSection === section}"
+               ng-if="familiesToShow.indexOf(section.type) >= 0"
+               ng-click="vm.selectedSection = section">
+                <i class="fa fa-fw" ng-class="section.icon"></i>
+            </a>
+        </div>
+    </div>
 
-    <catalog-selector family="family" on-select="onTypeSelected(item)" items-per-page="catalogItemsPerPage"></catalog-selector>
+    <designer></designer>
+</div>
 
-</div></div></div>
+<div class="pane pane-palette" ng-if="vm.selectedSection">
+    <div ng-repeat="section in vm.sections track by $index"
+         class="palette-full-height-wrapper"
+         ng-if="vm.selectedSection === section">
+        <div class="container-fluid palette-title">
+            <h3>
+                {{section.title}}
+                <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
+            </h3>
+        </div>
+        <catalog-selector state="paletteState" family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
+    </div>
+</div>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.js
@@ -27,17 +27,18 @@ export const graphicalEditAddState = {
     name: 'main.graphical.edit.add',
     url: '/add/:family?configKey',
     template: template,
-    controller: ['$scope', '$filter', '$state', '$stateParams', 'blueprintService', GraphicalEditAddController],
+    controller: ['$scope', '$filter', '$state', '$stateParams', 'blueprintService', 'paletteService', GraphicalEditAddController],
     controllerAs: 'vm',
 };
 
-export function GraphicalEditAddController($scope, $filter, $state, $stateParams, blueprintService) {
+export function GraphicalEditAddController($scope, $filter, $state, $stateParams, blueprintService, paletteService) {
     switch ($stateParams.family) {
         case EntityFamily.ENTITY.id.toLowerCase():
             $scope.family = EntityFamily.ENTITY;
             break;
         case EntityFamily.SPEC.id.toLowerCase():
             $scope.family = EntityFamily.SPEC;
+            $scope.familiesToShow = [ EntityFamily.ENTITY, EntityFamily.SPEC ];
             $scope.configKey = $stateParams.configKey;
             break;
         case EntityFamily.POLICY.id.toLowerCase():
@@ -51,8 +52,11 @@ export function GraphicalEditAddController($scope, $filter, $state, $stateParams
             break;
     }
 
-    $scope.catalogItemsPerPage = 24;
-
+    if (!$scope.familiesToShow) $scope.familiesToShow = [ $scope.family ];
+    
+    this.sections = paletteService.getSections();
+    this.selectedSection = Object.values(this.sections).find(section => $scope.familiesToShow.indexOf(section.type) >= 0);
+    
     $scope.getParentLink = ()=> {
         let state = graphicalEditEntityState;
         let params = {entityId: $scope.entity.hasParent() ? $scope.entity.parent._id : $scope.entity._id};
@@ -83,7 +87,7 @@ export function GraphicalEditAddController($scope, $filter, $state, $stateParams
         return label;
     };
 
-    $scope.onTypeSelected = (type)=> {
+    this.onTypeSelected = (type)=> {
         switch ($scope.family) {
             case EntityFamily.ENTITY:
                 let newEntity = blueprintService.populateEntityFromApi(new Entity(), type);

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.js
@@ -52,7 +52,9 @@ export function GraphicalEditAddController($scope, $filter, $state, $stateParams
             break;
     }
 
-    if (!$scope.familiesToShow) $scope.familiesToShow = [ $scope.family ];
+    if (!$scope.familiesToShow) {
+        $scope.familiesToShow = [ $scope.family ];
+    }
     
     this.sections = paletteService.getSections();
     this.selectedSection = Object.values(this.sections).find(section => $scope.familiesToShow.indexOf(section.type) >= 0);

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -34,14 +34,15 @@
 
 <div class="pane pane-palette" ng-if="vm.selectedSection">
     <div ng-repeat="section in vm.sections track by $index"
+         class="palette-full-height-wrapper"
          ng-if="vm.selectedSection === section">
-        <div class="container-fluid">
+        <div class="container-fluid palette-title">
             <h3>
                 {{section.title}}
                 <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
-        <catalog-selector family="section.type" on-select="vm.onTypeSelected(item)" items-per-page="vm.catalogItemsPerPage"></catalog-selector>
+        <catalog-selector family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
     </div>
 </div>
 

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -42,7 +42,7 @@
                 <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
-        <catalog-selector state="paletteState" family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
+        <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
     </div>
 </div>
 

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -17,7 +17,9 @@
   under the License.
 -->
 
-<div class="layout">
+<div class="palette-and-or-toolbar">
+
+  <div class="layout">
     <div class="toolbar">
         <div class="list-group">
             <a href class="list-group-item"
@@ -30,9 +32,9 @@
     </div>
 
     <designer></designer>
-</div>
+  </div>
 
-<div class="pane pane-palette" ng-if="vm.selectedSection">
+  <div class="pane pane-palette" ng-if="vm.selectedSection">
     <div ng-repeat="section in vm.sections track by $index"
          class="palette-full-height-wrapper"
          ng-if="vm.selectedSection === section">
@@ -44,8 +46,10 @@
         </div>
         <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
     </div>
-</div>
+  </div>
 
-<div class="pane pane-configuration">
+  <div class="pane pane-configuration">
     <ui-view></ui-view>
+  </div>
+
 </div>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -42,7 +42,7 @@
                 <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
-        <catalog-selector family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
+        <catalog-selector state="state" family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
     </div>
 </div>
 

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -42,7 +42,7 @@
                 <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
-        <catalog-selector state="state" family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
+        <catalog-selector state="paletteState" family="section.type" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
     </div>
 </div>
 

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
@@ -40,6 +40,7 @@ function graphicalController($scope, $state, blueprintService, paletteService) {
 
     this.sections = paletteService.getSections();
     this.selectedSection = Object.values(this.sections).find(section => section.type === EntityFamily.ENTITY);
+    $scope.state = {};  // share state among all sections
 
     this.onTypeSelected = (selectedType)=> {
         let rootEntity = blueprintService.get();

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
@@ -40,7 +40,7 @@ function graphicalController($scope, $state, blueprintService, paletteService) {
 
     this.sections = paletteService.getSections();
     this.selectedSection = Object.values(this.sections).find(section => section.type === EntityFamily.ENTITY);
-    $scope.state = {};  // share state among all sections
+    $scope.paletteState = {};  // share state among all sections
 
     this.onTypeSelected = (selectedType)=> {
         let rootEntity = blueprintService.get();

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
@@ -37,7 +37,6 @@ export const graphicalState = {
 
 function graphicalController($scope, $state, blueprintService, paletteService) {
     this.EntityFamily = EntityFamily;
-    this.catalogItemsPerPage = 24;
 
     this.sections = paletteService.getSections();
     this.selectedSection = Object.values(this.sections).find(section => section.type === EntityFamily.ENTITY);

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -86,6 +86,8 @@
       display: flex;
       flex-direction: column;
       flex: 1 1 auto;
+      margin-left: 0;
+      margin-right: 0;
     }
     
     h3 {

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -19,7 +19,12 @@
 
 .layout {
   display: flex;
+  designer {
+    flex-grow: 1;
+  }
+}
 
+.palette-and-or-toolbar {
   .toolbar {
     position: relative;
     height: calc(~"100vh - 105px");
@@ -59,9 +64,6 @@
     }
   }
 
-  designer {
-    flex-grow: 1;
-  }
 }
 
 .pane {
@@ -118,6 +120,25 @@
       padding: 0;
     }
 
+    .add-panel {
+        display: flex;
+        flex-direction: column;
+        > .spec-parent {
+            flex: 0 0 auto;
+        } 
+        > .add-panel-main {
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: row;
+            .toolbar {
+                flex: 0 0 auto;
+            }
+            .pane-palette {
+                flex: 1 1 auto;
+            }
+        }
+    }
+    
     .spec-parent {
       a {
         background-color: @gray-lighter;

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -63,7 +63,67 @@
       }
     }
   }
+  
+  #palette-controls-button {
+    margin-right: -2px;  // not sure why the default -1px doesn't work to merge the borders?
+  }
 
+  .pane-nav-row {
+    border: solid 1px @gray-lighter;
+    border-top: none;
+    border-radius: 5px;
+    margin-top: -5px;
+    padding: 12px 5px 4px 5px;
+    display: flex;
+    
+    .filters {
+        flex: 1 1 auto;
+        overflow: hidden;
+        display: flex;
+        flex-wrap: wrap;
+        
+        max-height: 24px;  // if things wrap hide them
+        &.multiline {      // unless toggled multiline
+            max-height: max-content; 
+        }
+        
+        .spacer {
+            flex: 0 0.5 1ex;
+        }
+    }
+    
+    .nav-row-item {
+      color: @gray-light;
+      flex: 0 0 auto;
+      margin: 6px 3px;
+      &.tool {
+        margin-top: 4px;
+      }
+      cursor: hand;
+    }
+    .nav-row-item:hover {
+        color: @brand-primary;
+    }
+    span[uib-dropdown] {
+        align-self: start;
+    }
+
+    a[aria-expanded="true"] {
+        > div.nav-row-item {
+            color: @brand-primary;
+        }
+    }
+    
+    .spacer {
+        flex: 1 1 2em;
+    }
+    
+    .right-align-icon {
+        position: absolute;
+        left: auto;
+        right: 0;
+    }
+  }
 }
 
 .pane {

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -77,6 +77,17 @@
     width: 440px;
     box-shadow: 5px 0 10px -2px @navbar-default-border;
 
+    .palette-title {
+        margin-left: 0;
+        margin-right: 0;
+    }    
+    
+    &, .palette-full-height-wrapper {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+    }
+    
     h3 {
       color: @gray-light;
     }

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -82,7 +82,7 @@
         display: flex;
         flex-wrap: wrap;
         
-        max-height: 24px;  // if things wrap hide them
+        max-height: 27px;  // if things wrap hide them
         &.multiline {      // unless toggled multiline
             max-height: max-content; 
         }

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -106,9 +106,14 @@
 
     & > ui-view > ui-view {
       display: block;
-      width: 440px;
+      width: 489px;
     }
 
+    .pane-palette .container-fluid {
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+    
     .container-fluid {
       padding: 0;
     }

--- a/ui-modules/blueprint-composer/app/views/main/main.less
+++ b/ui-modules/blueprint-composer/app/views/main/main.less
@@ -24,6 +24,10 @@
   border-radius: 0;
   border-color: @navbar-default-border;
   z-index: 50;
+  
+  .container-fluid.flush-left {
+    padding-left: 0;
+  }
 
   .navbar-nav > li > a {
     color: @gray-lighter;
@@ -35,10 +39,15 @@
   .navbar-nav-mode > .active > a:hover,
   .navbar-nav-mode > .active > a:focus {
     border-bottom: 5px solid @brand-primary;
+    background-color: #666666;
 
     & > i.fa {
       color: @brand-primary;
     }
+  }
+  
+  custom-action {
+    margin-left: 8px;
   }
 }
 
@@ -59,10 +68,10 @@
   }
   .layer a {
     cursor: pointer;
-    color: @gray-lighter;
+    color: @gray-light;
     transition: color 0.3s ease;
     &:hover {
-      color: @gray-light;
+      color: @gray-dark;
     }
   }
   .layer.active a {
@@ -70,6 +79,13 @@
     &:hover {
       color: @brand-primary;
     }
+  }
+  .dropdown-header {
+    background: @gray;
+    color: @gray-lighter;
+    font-weight: bold;
+    text-align: center;
+    padding-top: 7px;
   }
   .tab-content {
     width: 100%;

--- a/ui-modules/blueprint-composer/app/views/main/main.template.html
+++ b/ui-modules/blueprint-composer/app/views/main/main.template.html
@@ -19,7 +19,7 @@
 
 <header>
     <nav class="navbar navbar-mode">
-        <div class="container-fluid">
+        <div class="container-fluid flush-left">
             <ul class="nav navbar-nav navbar-nav-mode">
                 <li ng-class="{'active': vm.isGraphicalMode()}">
                     <a ui-sref="main.graphical" ng-disabled="vm.parseError">

--- a/ui-modules/blueprint-composer/package.json
+++ b/ui-modules/blueprint-composer/package.json
@@ -53,6 +53,7 @@
     "bootstrap": "^3.3.7",
     "codemirror": "^5.19.0",
     "d3": "4.10.0",
+    "date-fns": "^1.29.0",
     "es6-promise": "^4.0.5",
     "file-saver": "^1.3.3",
     "font-awesome": "^4.6.3",
@@ -60,8 +61,7 @@
     "lodash": "^4.16.4",
     "ngclipboard": "^1.1.1",
     "normalizr": "^2.2.1",
-    "underscore": "^1.8.3",
-    "moment": "^2.15.1"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "angular-mocks": "^1.6.1",

--- a/ui-modules/blueprint-composer/package.json
+++ b/ui-modules/blueprint-composer/package.json
@@ -60,7 +60,8 @@
     "lodash": "^4.16.4",
     "ngclipboard": "^1.1.1",
     "normalizr": "^2.2.1",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "moment": "^2.15.1"
   },
   "devDependencies": {
     "angular-mocks": "^1.6.1",

--- a/ui-modules/utils/br-core/style/buttons.less
+++ b/ui-modules/utils/br-core/style/buttons.less
@@ -24,7 +24,7 @@
     .button-variant(@btn-accent-color; @btn-accent-bg; @btn-accent-border);
 }
 
-.btn-ouline {
+.btn-outline {
     &.btn-primary:not(:hover) {
         background-color: transparent;
         color: @brand-primary;


### PR DESCRIPTION
store how recently an entity or palette icon was used in the composer, and introduce a filter and sort to use this info.  also move sorts and dropdown to new places as shown below.  fix sort (was not working), allow multi-sort (just remembers the last things you sorted from, does not show them), and add a footer to describe the results of sorts and filters

builds on #93 so review that first (or review the two togethers

<img width="528" alt="screen shot 2018-10-26 at 12 15 19" src="https://user-images.githubusercontent.com/496540/47563212-edfca480-d918-11e8-91c7-67818070dfb6.png">
