### PR TITLE
Relevance and other composer tweaks

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -33,9 +33,10 @@ const PALETTE_VIEW_ORDERS = {
     };
 
 const PALETTE_VIEW_MODES = {
-        compact: { name: "Compact", classes: "col-xs-2 item-compact", itemsPerRow: 6, rowHeightPx: 75, hideName: true },
-        normal: { name: "Normal", classes: "col-xs-3", itemsPerRow: 4 },
-        large: { name: "Large", classes: "col-xs-4", itemsPerRow: 3 },
+        tiny: { name: "Tiny", classes: "col-xs-2 item-compact", itemsPerRow: 6, rowHeightPx: 75, hideName: true },
+        compact: { name: "Compact", classes: "col-xs-3", itemsPerRow: 4 },
+        normal: { name: "Normal", classes: "col-xs-4", itemsPerRow: 3 },
+        large: { name: "Large", classes: "col-xs-6", itemsPerRow: 2 },
         list: { name: "List", classes: "col-xs-12 item-full-width", itemsPerRow: 1 },
     };
 

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -241,30 +241,32 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
         }
     }
     $scope.mouseInfoPopover = (item, enter) => {
-        if ($scope.popoverModal && $scope.popover==item) {
+        if ($scope.popoverModal && $scope.popoverVisible && $scope.popover==item) {
             // ignore if modal
             return;
         }
         $scope.popoverModal = false;
         if (enter) {
             $scope.popover = item;
+            $scope.popoverVisible = true;
         } else {
-            $scope.popover = null;
+            $scope.popoverVisible = false;
         }
     }
     $scope.onClickItem = (item, isInfoIcon, $event) => {
         if (!isInfoIcon && $scope.iconSelects) {
             $scope.onSelectItem(item);
-        } else if ($scope.popoverModal && $scope.popover == item) {
+        } else if ($scope.popoverModal && $scope.popoverVisible && $scope.popover == item) {
             $scope.closePopover();
         } else {
             $scope.popover = item;
+            $scope.popoverVisible = true;
             $scope.popoverModal = true;
         }
         $event.stopPropagation();
     }
     $scope.closePopover = () => {
-        $scope.popover = null;
+        $scope.popoverVisible = false;
         $scope.popoverModal = false;
     }
     $scope.getOnSelectText = function (item) {
@@ -365,7 +367,6 @@ function controller($scope, $element, $timeout, $q, $uibModal, $log, $templateCa
         if (l < 100000) return 'Preselected for inclusion in "Recent" filter.';
         return 'Last used: ' + distanceInWordsToNow(l, { includeSeconds: true, addSuffix: true });
     }; 
-    $scope.roundTwoDecimals = (num) => Math.round(num*100)/100.0;
     
     $scope.showPaletteControls = false;
     $scope.onFiltersShown = () => {

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -291,6 +291,9 @@ catalog-selector {
         margin-top: -3px;
         margin-bottom: 12px;
         padding: 0px 16px 6px 16px;
+        .closer {
+            margin-top: 6px;
+        }
     }
     .closer {
         width: 10px;
@@ -310,6 +313,11 @@ catalog-selector {
             padding: 6px 9px;
             line-height: 1;
             margin-left: 12px;
+        }
+        .select-item-button {
+            flex: 0 1 auto;
+            text-overflow: ellipsis;
+            overflow: hidden;
         }
     }
   }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -264,6 +264,9 @@ catalog-selector {
       .label {
         line-height: 2.2;
       }
+      .closer .br-icon-close-bar {
+        stroke: @brand-primary;
+      }
     }
     .deprecated-marker {
       float: right;
@@ -279,6 +282,35 @@ catalog-selector {
     }
     .palette-item-tag {
         margin-right: 4px;
+    }
+    .quick-info-title {
+        background-color: @gray-lightest;
+        border-bottom: 1px solid @popover-border-color;
+        margin-left: -15px;
+        margin-right: -15px;
+        margin-top: -3px;
+        margin-bottom: 12px;
+        padding: 0px 16px 6px 16px;
+    }
+    .closer {
+        width: 10px;
+        > svg { width: 10px; } 
+        cursor: pointer;
+        margin-left: 6px;
+    }
+    .quick-info-buttons {
+        border-top: 1px solid @popover-border-color;
+        margin-top: 10px;
+        padding-top: 10px;
+        display: flex;
+        div.spacer {
+            flex: 1 1 auto;
+        }
+        button {
+            padding: 6px 9px;
+            line-height: 1;
+            margin-left: 12px;
+        }
     }
   }
 

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.less
@@ -288,9 +288,10 @@ catalog-selector {
         border-bottom: 1px solid @popover-border-color;
         margin-left: -15px;
         margin-right: -15px;
-        margin-top: -3px;
+        margin-top: -10px;
         margin-bottom: 12px;
-        padding: 0px 16px 6px 16px;
+        padding: 8px 16px 6px 16px;
+        border-radius: 5px 5px 0 0;
         .closer {
             margin-top: 6px;
         }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -74,7 +74,7 @@
                     <i class="fa fa-sort"></i></div>
                 </a>
                 <ul class="dropdown-menu right-align-icon" role="menu" uib-dropdown-menu aria-labelledby="palette-sort">
-                        <li role="menuitem" ng-repeat="order in viewOrders track by $index" ng-class="{'active': state.currentOrder[0] === order.field}" class="layer">
+                        <li role="menuitem" ng-repeat="order in state.currentOrderValues track by $index" class="layer">
                             <a ng-click="sortBy(order)"><i class="fa fa-fw fa-circle"></i> {{ order.label }}</a>
                         </li>
                 </ul>
@@ -100,7 +100,7 @@
             <!-- here and below, col-xs-3 or -4 or -2 all work giving different densities;
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
             <div class="catalog-palette-item" ng-class="state.viewMode.classes"
-                    ng-repeat="item in searchedItems = (items | catalogSelectorSearch:search | catalogSelectorFilters:this) | orderBy:state.currentOrder | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
+                    ng-repeat="item in searchedItems = (items | catalogSelectorSearch:search | catalogSelectorFilters:this) | orderBy:state.currentOrderFields | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
                     ng-click="onSelectItem(item)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(item, $event)" ng-dragend="onDragEnd(item, $event)">
                     <div class="item-logo">
@@ -157,6 +157,7 @@
                 <span ng-repeat-start="tag in item.displayTags" class="label label-primary palette-item-tag">{{ tag }}</span>
                 <span ng-repeat-end> </span> </p>
             <p><i class="mini-icon fa fa-fw fa-file-zip-o"></i> {{item.containingBundle}}</p>
+            <p ng-if="item.relevance"><i class="mini-icon fa fa-sort-numeric-asc"></i> Relevance score: {{ roundTwoDecimals(item.relevance) }}</p>
         </div>
     </div>
 </script>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -101,7 +101,7 @@
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
             <div class="catalog-palette-item" ng-class="state.viewMode.classes"
                     ng-repeat="item in searchedItems = (items | catalogSelectorSearch:search | catalogSelectorFilters:this) | orderBy:state.currentOrderFields | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
-                    ng-click="onSelectItem(item)">
+                    ng-click="onClickItem(item, $event)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(item, $event)" ng-dragend="onDragEnd(item, $event)">
                     <div class="item-logo">
                         <img ng-src="{{item | iconGeneratorPipe:'symbolicName'}}" alt="{{item.displayName}} logo" on-error="onImageError" item-id="{{item.symbolicName}}"/>
@@ -111,16 +111,17 @@
                     </div>
                     <i class="fa fa-info-circle"
                         uib-popover-template="'QuickInfoTemplate.html'"
-                        popover-title="{{item | entityName}}"
-                        popover-placement="right-top" popover-trigger="'mouseenter'"
+                        popover-is-open="popover == item"
+                        popover-placement="right" popover-trigger="'none'"
                         popover-class="catalog-selector-popover" popover-append-to-body="true"
-                        ng-click="$event.stopPropagation()"></i>
+                        ng-mouseenter="mouseInfoPopover(item, true)"
+                        ng-mouseleave="mouseInfoPopover(item, false)"></i>
                 </div>
             </div>
 
             <div class="catalog-palette-item"
                     ng-class="state.viewMode.classes" 
-                    ng-if="searchedItems.length === 0 && search && allowFreeForm()" ng-click="onSelectItem(freeFormTile)">
+                    ng-if="searchedItems.length === 0 && search && allowFreeForm()" ng-click="onClickItem(freeFormTile, $event)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(freeFormTile, $event)" ng-dragend="onDragEnd(freeFormTile, $event)">
                     <div class="item-logo">
                         <img ng-src="{{freeFormTile | iconGeneratorPipe:'symbolicName'}}" alt="{{freeFormTile.displayName}} logo" on-error="onImageError" item-id="{{freeFormTile.symbolicName}}"/>
@@ -128,6 +129,13 @@
                     <div class="item-content" ng-hide="state.viewMode.hideName">
                         <h3>{{freeFormTile | entityName}}</h3>
                     </div>
+                    <i class="fa fa-info-circle"
+                        uib-popover-template="'QuickInfoTemplate.html'"
+                        popover-is-open="popover == freeFormTile"
+                        popover-placement="right-top" popover-trigger="'none'"
+                        popover-class="catalog-selector-popover" popover-append-to-body="true"
+                        ng-mouseenter="mouseInfoPopover(freeFormTile, true)"
+                        ng-mouseleave="mouseInfoPopover(freeFormTile, false)"></i>
                 </div>
                 <div class="text-danger" ng-if="isReserved()">
                     Cannot add <code>{{freeFormTile.symbolicName}}</code> because it is reserved.
@@ -145,19 +153,29 @@
 <!-- QUICK INFO TEMPLATE :: START-->
 <script type="text/ng-template" id="QuickInfoTemplate.html">
     <div class="palette-item-quick-info">
-        <div class="deprecated-marker" ng-if="item.deprecated">DEPRECATED</div>
-        <div class="quick-info-metadata">
-            <p><i class="mini-icon fa fa-fw fa-bookmark"></i> <samp class="type-symbolic-name">{{item.symbolicName}}</samp></p>
-            <p ng-if="item.version"><i class="mini-icon fa fa-fw fa-code-fork"></i> {{item.version}}</p>
+        <div class="quick-info-title">{{ popover | entityName }}
+            <br-svg type="close" class="pull-right closer" ng-click="closePopover()"></br-svg>
         </div>
-        <p class="quick-info-description" ng-if="item.description">{{item.description}}</p>
+        <div class="deprecated-marker" ng-if="popover.deprecated">DEPRECATED</div>
+        <div class="quick-info-metadata">
+            <p><i class="mini-icon fa fa-fw fa-bookmark"></i> <samp class="type-symbolic-name">{{popover.symbolicName}}</samp></p>
+            <p ng-if="popover.version"><i class="mini-icon fa fa-fw fa-code-fork"></i> {{popover.version}}</p>
+        </div>
+        <p class="quick-info-description" ng-if="popover.description">{{popover.description}}</p>
         <div class="quick-info-metadata bundle">
-            <p ng-if="lastUsedText(item)"><i class="mini-icon fa fa-clock-o"></i> {{ lastUsedText(item) }}</p>
-            <p ng-if="item.displayTags && item.displayTags.length"><i class="mini-icon fa fa-fw fa-tags"></i> 
-                <span ng-repeat-start="tag in item.displayTags" class="label label-primary palette-item-tag">{{ tag }}</span>
+            <p ng-if="lastUsedText(popover)"><i class="mini-icon fa fa-clock-o"></i> {{ lastUsedText(popover) }}
+              <br-svg type="close" class="closer" ng-click="popover.lastUsed = 0"></br-svg>
+            </p>
+            <p ng-if="popover.displayTags && popover.displayTags.length"><i class="mini-icon fa fa-fw fa-tags"></i> 
+                <span ng-repeat-start="tag in popover.displayTags" class="label label-primary palette-item-tag">{{ tag }}</span>
                 <span ng-repeat-end> </span> </p>
-            <p><i class="mini-icon fa fa-fw fa-file-zip-o"></i> {{item.containingBundle}}</p>
-            <p ng-if="item.relevance"><i class="mini-icon fa fa-sort-numeric-asc"></i> Relevance score: {{ roundTwoDecimals(item.relevance) }}</p>
+            <p><i class="mini-icon fa fa-fw fa-file-zip-o"></i> {{popover.containingBundle}}</p>
+            <p ng-if="popover.relevance"><i class="mini-icon fa fa-sort-numeric-asc"></i> Relevance score: {{ roundTwoDecimals(popover.relevance) }}</p>
+        </div>
+        <div class="quick-info-buttons">
+            <div class="spacer"></div>
+            <button class="btn btn-primary btn-outline" ng-click="onSelectItemToAdd(popover)">{{ onSelectText || "Select" }}</button>
+            <a ng-if="popover.containingBundle" href="{{ getOpenCatalogLink(popover) }}" target="_blank"><button class="btn btn-info btn-outline">Open in catalog</button></a>
         </div>
     </div>
 </script>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -101,7 +101,7 @@
                  this could be configurable ("compressed"=xs-2 w no labels, "normal"=xs-3, "big"=xs-4) -->
             <div class="catalog-palette-item" ng-class="state.viewMode.classes"
                     ng-repeat="item in searchedItems = (items | catalogSelectorSearch:search | catalogSelectorFilters:this) | orderBy:state.currentOrderFields | limitTo:pagination.itemsPerPage:(pagination.page-1)*pagination.itemsPerPage track by (item.containingBundle + ':' + item.symbolicName + ':' + item.version)"
-                    ng-click="onClickItem(item, $event)">
+                    ng-click="onClickItem(item, false, $event)">
                 <div class="item" draggable="true" ng-dragstart="onDragItem(item, $event)" ng-dragend="onDragEnd(item, $event)">
                     <div class="item-logo">
                         <img ng-src="{{item | iconGeneratorPipe:'symbolicName'}}" alt="{{item.displayName}} logo" on-error="onImageError" item-id="{{item.symbolicName}}"/>
@@ -111,6 +111,7 @@
                     </div>
                     <i class="fa fa-info-circle"
                         uib-popover-template="'QuickInfoTemplate.html'"
+                        ng-click="onClickItem(item, true, $event)"
                         popover-is-open="popover == item"
                         popover-placement="right" popover-trigger="'none'"
                         popover-class="catalog-selector-popover" popover-append-to-body="true"
@@ -174,8 +175,8 @@
         </div>
         <div class="quick-info-buttons">
             <div class="spacer"></div>
-            <button class="btn btn-primary btn-outline" ng-click="onSelectItemToAdd(popover)">{{ onSelectText || "Select" }}</button>
-            <a ng-if="popover.containingBundle" href="{{ getOpenCatalogLink(popover) }}" target="_blank"><button class="btn btn-info btn-outline">Open in catalog</button></a>
+            <button class="btn btn-primary btn-outline select-item-button" ng-click="onSelectItem(popover, false, $event)">{{ getOnSelectText(popover) }}</button>
+            <a ng-if="popover.containingBundle && allowOpenInCatalog" href="{{ getOpenCatalogLink(popover) }}" target="_blank"><button class="btn btn-info btn-outline">Open in catalog</button></a>
         </div>
     </div>
 </script>

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -112,7 +112,7 @@
                     <i class="fa fa-info-circle"
                         uib-popover-template="'QuickInfoTemplate.html'"
                         ng-click="onClickItem(item, true, $event)"
-                        popover-is-open="popover == item"
+                        popover-is-open="popover == item && popoverVisible"
                         popover-placement="right" popover-trigger="'none'"
                         popover-class="catalog-selector-popover" popover-append-to-body="true"
                         ng-mouseenter="mouseInfoPopover(item, true)"
@@ -132,7 +132,7 @@
                     </div>
                     <i class="fa fa-info-circle"
                         uib-popover-template="'QuickInfoTemplate.html'"
-                        popover-is-open="popover == freeFormTile"
+                        popover-is-open="popover == freeFormTile && popoverVisible"
                         popover-placement="right-top" popover-trigger="'none'"
                         popover-class="catalog-selector-popover" popover-append-to-body="true"
                         ng-mouseenter="mouseInfoPopover(freeFormTile, true)"
@@ -163,6 +163,7 @@
             <p ng-if="popover.version"><i class="mini-icon fa fa-fw fa-code-fork"></i> {{popover.version}}</p>
         </div>
         <p class="quick-info-description" ng-if="popover.description">{{popover.description}}</p>
+        <p class="quick-info-description" ng-if="popover == freeFormTile">This is an ad hoc tile for an item entered by the user not known in the catalog.</p>
         <div class="quick-info-metadata bundle">
             <p ng-if="lastUsedText(popover)"><i class="mini-icon fa fa-clock-o"></i> {{ lastUsedText(popover) }}
               <br-svg type="close" class="closer" ng-click="popover.lastUsed = 0"></br-svg>
@@ -170,8 +171,8 @@
             <p ng-if="popover.displayTags && popover.displayTags.length"><i class="mini-icon fa fa-fw fa-tags"></i> 
                 <span ng-repeat-start="tag in popover.displayTags" class="label label-primary palette-item-tag">{{ tag }}</span>
                 <span ng-repeat-end> </span> </p>
-            <p><i class="mini-icon fa fa-fw fa-file-zip-o"></i> {{popover.containingBundle}}</p>
-            <p ng-if="popover.relevance"><i class="mini-icon fa fa-sort-numeric-asc"></i> Relevance score: {{ roundTwoDecimals(popover.relevance) }}</p>
+            <p ng-if="popover.containingBundle"><i class="mini-icon fa fa-fw fa-file-zip-o"></i> {{popover.containingBundle}}</p>
+            <p ng-if="popover.relevance"><i class="mini-icon fa fa-sort-numeric-asc"></i> Relevance score: {{ popover.relevance | number:2 }}</p>
         </div>
         <div class="quick-info-buttons">
             <div class="spacer"></div>

--- a/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
+++ b/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
@@ -29,6 +29,9 @@ const TAG = 'DIRECTIVE :: DESIGNER :: ';
 export function designerDirective($log, $state, $q, iconGenerator, catalogApi, blueprintService, brSnackbar, paletteDragAndDropService) {
     let directive = {
         restrict: 'E',
+        scope: {
+            onSelectionChange: '<?'
+        },
         template: '',
         link: link
     };
@@ -109,13 +112,16 @@ export function designerDirective($log, $state, $q, iconGenerator, catalogApi, b
                     break;
             }
             if (angular.isDefined(id)) {
+                $log.debug(TAG + 'Select canvas, selected node: ' + id);
                 $scope.selectedEntity = blueprintService.findAny(id);
+                if ($scope.onSelectionChange) $scope.onSelectionChange($scope.selectedEntity);
             }
         });
 
         $element.bind('click-svg', (event)=> {
             $log.debug(TAG + 'Select canvas, un-select node (if one selected before)');
             $scope.selectedEntity = null;
+            if ($scope.onSelectionChange) $scope.onSelectionChange($scope.selectedEntity);
             $scope.$apply(()=> {
                 redrawGraph();
                 $state.go('main.graphical');

--- a/ui-modules/blueprint-composer/app/components/filters/entity.filter.js
+++ b/ui-modules/blueprint-composer/app/components/filters/entity.filter.js
@@ -16,11 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-const DEFAULT = '';
-
 export function entityNameFilter() {
     return function (input) {
-        var result = input ? (input.displayName || input.name || input.symbolicName || input.type || DEFAULT) : DEFAULT;
+        var result = input ? (input.displayName || input.name || input.symbolicName || input.type || null) : null;
+        if (!result) {
+            if (input && !input.parent) result = 'Application';
+            else result = 'Unnamed entity';
+        }
         if (result.match(/^[^\w]*deprecated[^\w]*/i)) {
             result = result.replace(/^[^\w]*deprecated[^\w]*/i, '');
         }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -78,13 +78,15 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         scope: {
             model: '='
         },
-        controller: controller,
+        controller: ['$scope', '$element', controller],
         template: template,
         link: link,
         controllerAs: 'specEditor',
     };
 
-    function controller() {
+    function controller($scope, $element) {
+        (composerOverrides.configureSpecEditorController || function() {})(this, $scope, $element);
+        
         // does very little currently, but link adds to this
         return this;
     }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -320,7 +320,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 scope.state.config.filter.values.all = true;
             }
         };
-        scope.recordFocus = specEditor.recordFocus = ($item)=> {
+        scope.recordFocus = specEditor.recordFocus = ($item) => {
             scope.state.config.focus = $item.name;
         };
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -341,7 +341,9 @@
 </br-collapsible>
 
 <!-- ENTITY LOCATION -->
-<br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.location.open">
+<ng-include src="'SpecEditorLocationSection.html'"></ng-include>
+<script type="text/ng-template" id="SpecEditorLocationSection.html">
+  <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.location.open">
     <heading>
         Location
         <span ng-if="(model.issues | filter:{group:'location'}).length> 0" class="badge" ng-class="getBadgeClass((model.issues | filter:{group:'location'}))">{{(model.issues | filter:{group:'location'}).length}}</span>
@@ -365,10 +367,13 @@
             <button class="btn btn-danger btn-link" ng-click="model.clearIssues({group: 'location'}).removeLocation()">Remove</button>
         </div>
     </div>
-</br-collapsible>
+  </br-collapsible>
+</script>
 
 <!-- ENTITY POLICIES -->
-<br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.policy.open">
+<ng-include src="'SpecEditorPoliciesSection.html'"></ng-include>
+<script type="text/ng-template" id="SpecEditorPoliciesSection.html">
+  <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.policy.open">
     <heading>
         Policies
         <span ng-if="getPoliciesIssues().length> 0" class="badge" ng-class="getBadgeClass(getPoliciesIssues())">{{getPoliciesIssues().length}}</span>
@@ -398,10 +403,13 @@
             <ng-include src="'AdjunctTemplate.html'"></ng-include>
         </div>
     </div>
-</br-collapsible>
+  </br-collapsible>
+</script>
 
 <!-- ENTITY ENRICHERS -->
-<br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.enricher.open">
+<ng-include src="'SpecEditorEnrichersSection.html'"></ng-include>
+<script type="text/ng-template" id="SpecEditorEnrichersSection.html">
+  <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.enricher.open">
     <heading>
         Enrichers
         <span ng-if="getEnrichersIssues().length> 0" class="badge" ng-class="getBadgeClass(getEnrichersIssues())">{{getEnrichersIssues().length}}</span>
@@ -431,7 +439,13 @@
             <ng-include src="'AdjunctTemplate.html'"></ng-include>
         </div>
     </div>
-</br-collapsible>
+  </br-collapsible>
+</script>
+
+<ng-include src="'SpecEditorOtherSections.html'"></ng-include>
+<script type="text/ng-template" id="SpecEditorOtherSections.html">
+</script>
+
 
 <!-- CONFIG INFO TEMPLATE :: START -->
 <script type="text/ng-template" id="ConfigInfoTemplate.html">

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
@@ -45,7 +45,7 @@
                 <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
-        <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
+        <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.onTypeSelected(item)" on-select-text="vm.getOnSelectText(item)" icon-selects="true" class="palette-full-height-wrapper"></catalog-selector>
     </div>
   </div>
  </div>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.js
@@ -88,6 +88,17 @@ export function GraphicalEditAddController($scope, $filter, $state, $stateParams
 
         return label;
     };
+    
+    this.getOnSelectText = () => {
+        switch ($scope.family) {
+            case EntityFamily.ENTITY: return "Add as child";
+            case EntityFamily.SPEC: return "Set as spec";
+            case EntityFamily.POLICY: return "Add this policy";
+            case EntityFamily.ENRICHER: return "Add this enricher";
+            case EntityFamily.LOCATION: return "Add this location";
+        }
+        return "Select";
+    };
 
     this.onTypeSelected = (type)=> {
         switch ($scope.family) {

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -31,7 +31,7 @@
         </div>
     </div>
 
-    <designer></designer>
+    <designer on-selection-change="vm.onCanvasSelection"></designer>
   </div>
 
   <div class="pane pane-palette" ng-if="vm.selectedSection">
@@ -44,7 +44,7 @@
                 <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
-        <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.onTypeSelected(item)" class="palette-full-height-wrapper"></catalog-selector>
+        <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.addSelectedTypeToTargetEntity(item)" on-select-text="vm.getOnSelectText()" class="palette-full-height-wrapper"></catalog-selector>
     </div>
   </div>
 


### PR DESCRIPTION
Several things to make composer easier to use:

* When searching in palette, it now sorts by "Relevance" as primary order; relevance formula is a bit complicated, poor-man's AI :), but works pretty damn well (!)
* Sort is always multi-sort, and dropdown shows the sort order (this could do with more UI goodness to make that obvious, but it does the right thing if you interact with it; "relevance" above obviously has no effect when not searching so "name" as second-order search order is what you normally get)
* Default palette now shows 3 wide; with more height and longer names this seems better (4 wide aka "Compact" is an option)
* the Quick Info pane from the palette is now toggleable, and showing this is the default action if you click on a tile (not adding to the root of the application which was a bit surprising!); it has buttons for the previous "selection" action, and also a button to open in catalog
* selecting from palette adds to a focus entity if there is a focus entity
* extensible in several places, including the spec editor sections can be customized or removed

Below is a sample screen shot, for a downstream project that uses the UI (and has a lot of types), but the mods all apply to the stock brooklyn UI (though only really useful with a big catalog!):

<img width="1411" alt="screen shot 2018-11-01 at 12 25 13" src="https://user-images.githubusercontent.com/496540/47851889-e41fe900-ddd1-11e8-9864-917c668ebe43.png">
