### PR TITLE
improve logic and ui for inferring bundle and type name when saving to catalog

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
@@ -100,7 +100,7 @@ export function saveToCatalogModalDirective($rootScope, $uibModal, $injector, co
             let modalInstance = $uibModal.open({
                 templateUrl: TEMPLATE_MODAL_URL,
                 size: 'save',
-                controller: ['$scope', 'blueprintService', 'paletteApi', 'brUtilsGeneral', CatalogItemModalController],
+                controller: ['$scope', '$filter', 'blueprintService', 'paletteApi', 'brUtilsGeneral', CatalogItemModalController],
                 scope: $scope,
             });
 
@@ -119,7 +119,7 @@ export function saveToCatalogModalDirective($rootScope, $uibModal, $injector, co
     }
 }
 
-export function CatalogItemModalController($scope, blueprintService, paletteApi, brUtilsGeneral) {
+export function CatalogItemModalController($scope, $filter, blueprintService, paletteApi, brUtilsGeneral) {
     $scope.REASONS = REASONS;
     $scope.VIEWS = VIEWS;
     $scope.TYPES = TYPES;
@@ -160,8 +160,8 @@ export function CatalogItemModalController($scope, blueprintService, paletteApi,
     function createBom() {
         let blueprint = blueprintService.getAsJson();
 
-        let bundleBase = $scope.config.bundle || bundlize($scope.config.name);
-        let bundleId = $scope.config.symbolicName || bundlize($scope.config.name);
+        let bundleBase = $scope.config.bundle || $filter('bundlize')($scope.config.name);
+        let bundleId = $scope.config.symbolicName || $filter('bundlize')($scope.config.name);
         if (!bundleBase || !bundleId) {
             throw "Either display name must be set of bundle and symbolic name explicitly set";  
         }
@@ -229,6 +229,6 @@ function templateCache($templateCache) {
     $templateCache.put(TEMPLATE_MODAL_URL, modalTemplate);
 }
 
-var bundlize = (input) => input && input.split(/[^a-zA-Z0-9]+/).filter(x => x).join('-').toLowerCase();
-function bundlizeProvider() { return bundlize; }
-    
+function bundlizeProvider() { 
+    return (input) => input && input.split(/[^a-zA-Z0-9]+/).filter(x => x).join('-').toLowerCase(); 
+}

--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.modal.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.modal.template.html
@@ -24,9 +24,12 @@
 <div class="modal-body add-to-catalog-modal">
     <form ng-show="state.view === VIEWS.form" name="form" novalidate>
 
-        <div class="form-group">
+        <div class="form-group" ng-class="{'has-error': form.name.$invalid}">
             <label class="control-label">Blueprint display name</label>
-            <input ng-model="config.name" ng-disabled="state.saving" class="form-control" name="name" type="text" />
+            <input ng-model="config.name" ng-disabled="state.saving" class="form-control" name="name" type="text" required />
+            <p class="help-block" ng-show="form.name.$invalid">
+                <span ng-if="form.name.$error.required">You must specify a name for this item</span>
+            </p>
         </div>
 
         <div class="form-group">
@@ -57,19 +60,17 @@
                 <label class="control-label">Bundle ID</label>
                 <div class="input-group">
                     <span class="input-group-addon">catalog-bom-</span>
-                    <input ng-model="config.bundle" ng-disabled="state.saving" class="form-control" placeholder="E.g my-bundle" name="bundle" required ng-pattern="state.pattern" autofocus />
+                    <input ng-model="config.bundle" ng-disabled="state.saving" class="form-control" name="bundle" ng-pattern="state.pattern" autofocus placeholder="{{ config.name | bundlize }}"/>
                 </div>
                 <p class="help-block" ng-show="form.bundle.$invalid">
-                    <span ng-if="form.bundle.$error.required">You must specify a bundle ID</span>
                     <span ng-if="form.bundle.$error.pattern">The bundle ID can contains only letters, numbers as well a the following characters: <code>.</code>, <code>-</code> and <code>_</code></span>
                 </p>
             </div>
 
             <div class="form-group" ng-class="{'has-error': form.symbolicName.$invalid}">
                 <label class="control-label">Blueprint symbolic name</label>
-                <input ng-model="config.symbolicName" ng-disabled="state.saving" class="form-control" placeholder="E.g my-catalog-id" name="symbolicName" required ng-pattern="state.pattern" autofocus />
+                <input ng-model="config.symbolicName" ng-disabled="state.saving" class="form-control" name="symbolicName" ng-pattern="state.pattern" autofocus placeholder="{{ config.name | bundlize }}"/>
                 <p class="help-block" ng-show="form.symbolicName.$invalid">
-                    <span ng-if="form.symbolicName.$error.required">You must specify a blueprint symbolic name</span>
                     <span ng-if="form.symbolicName.$error.pattern">The blueprint symbolic name can contains only letters, numbers as well a the following characters: <code>.</code>, <code>-</code> and <code>_</code></span>
                 </p>
             </div>

--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.modal.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.modal.template.html
@@ -60,7 +60,7 @@
                 <label class="control-label">Bundle ID</label>
                 <div class="input-group">
                     <span class="input-group-addon">catalog-bom-</span>
-                    <input ng-model="config.bundle" ng-disabled="state.saving" class="form-control" name="bundle" ng-pattern="state.pattern" autofocus placeholder="{{ config.name | bundlize }}"/>
+                    <input ng-model="config.bundle" ng-disabled="state.saving" class="form-control" name="bundle" ng-pattern="state.pattern" autofocus placeholder="{{ (config.name | bundlize) || 'E.g. my-bundle-id' }}"/>
                 </div>
                 <p class="help-block" ng-show="form.bundle.$invalid">
                     <span ng-if="form.bundle.$error.pattern">The bundle ID can contains only letters, numbers as well a the following characters: <code>.</code>, <code>-</code> and <code>_</code></span>
@@ -69,7 +69,7 @@
 
             <div class="form-group" ng-class="{'has-error': form.symbolicName.$invalid}">
                 <label class="control-label">Blueprint symbolic name</label>
-                <input ng-model="config.symbolicName" ng-disabled="state.saving" class="form-control" name="symbolicName" ng-pattern="state.pattern" autofocus placeholder="{{ config.name | bundlize }}"/>
+                <input ng-model="config.symbolicName" ng-disabled="state.saving" class="form-control" name="symbolicName" ng-pattern="state.pattern" autofocus placeholder="{{ (config.name | bundlize) || 'E.g. my-catalog-id' }}"/>
                 <p class="help-block" ng-show="form.symbolicName.$invalid">
                     <span ng-if="form.symbolicName.$error.pattern">The blueprint symbolic name can contains only letters, numbers as well a the following characters: <code>.</code>, <code>-</code> and <code>_</code></span>
                 </p>


### PR DESCRIPTION
previously showed "untitled" if you clilcked to expand on a new blueprint, now defaults to tidied version of display name (which is required)