### PR TITLE
DSL editor: support referencing `brooklyn.parameters`

### DIFF
--- a/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
+++ b/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
@@ -287,6 +287,18 @@ export function dslEditorDirective($rootScope, $filter, $log, brUtilsGeneral, bl
             };
         });
 
+        let params = entity.miscData.get('parameters').filter(param => param !== definition).map(param => {
+            return {
+                id: param.name,
+                type: DSL_KINDS.CONFIG,
+                entity: entity,
+                name: param.name,
+                description: param.description
+            };
+        });
+        
+        config = config.concat(params);
+
         config = Object.values(entity.getClusterMemberspecEntities()).reduce((acc, spec) => {
             return acc.concat(getConfigItems(spec, definition));
         }, config);

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -245,11 +245,13 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
             entity.miscData.set('traits', []);
             deferred.resolve(entity);
             addUnlistedConfigKeysDefinitions(entity);
+            addUnlistedParameterDefinitions(entity);
         } else {
             entity.miscData.set('sensors', []);
             entity.miscData.set('traits', []);
             deferred.resolve(entity);
             addUnlistedConfigKeysDefinitions(entity);
+            addUnlistedParameterDefinitions(entity);
         }
 
         return deferred.promise;
@@ -512,6 +514,16 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         entity.miscData.set('config', allConfig);
     }
 
+    function addUnlistedParameterDefinitions(entity) {
+        let allParams = entity.miscData.get('parameters') || [];
+        entity.parameters.forEach((param) => {
+            if (!allParams.some((e) => e.name === param.name)) {
+                allParams.push(param);
+            }
+        });
+        entity.miscData.set('parameters', allParams);
+    }
+
     function populateEntityFromApiSuccess(entity, data) {
         entity.clearIssues({group: 'type'});
         entity.type = data.symbolicName;
@@ -523,6 +535,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         });
         entity.miscData.set('typeName', data.displayName || data.symbolicName);
         entity.miscData.set('config', data.config || []);
+        entity.miscData.set('parameters', data.parameters || []);
         entity.miscData.set('sensors', data.sensors || []);
         entity.miscData.set('traits', data.supertypes || []);
         entity.miscData.set('tags', data.tags || []);
@@ -533,6 +546,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         entity.miscData.set('ui-composer-hints', uiHints);
         entity.miscData.set('virtual', data.virtual || null);
         addUnlistedConfigKeysDefinitions(entity);
+        addUnlistedParameterDefinitions(entity);
         return entity;
     }
     function mergeAppendingLists(dst, src) {
@@ -552,11 +566,13 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         entity.addIssue(Issue.builder().group('type').message($sce.trustAsHtml(`Type <samp>${entity.type + (entity.hasVersion ? ':' + entity.version : '')}</samp> does not exist`)).build());
         entity.miscData.set('typeName', entity.type || '');
         entity.miscData.set('config', []);
+        entity.miscData.set('parameters', []);
         entity.miscData.set('sensors', []);
         entity.miscData.set('traits', []);
         entity.miscData.set('virtual', null);
         entity.icon = typeNotFoundIcon;
         addUnlistedConfigKeysDefinitions(entity);
+        addUnlistedParameterDefinitions(entity);
         return entity;
     }
 


### PR DESCRIPTION
Allows a blueprint to use `brooklyn.parameters`, and to reference that parameter using the DSL editor.

For example, I wrote the blueprint below in YAML (except the values of foo and bar), then switched to graphical view. I used the DSL editor to set the values for foo and bar to reference the brooklyn.parameters at the top-level app and on another entity.

```
brooklyn.config:
  toplevelkey: toplevelval
brooklyn.parameters:
  - name: toplevelParam
services:
  - type: server
    id: server1
    brooklyn.parameters:
      - name: MyParameter
        type: string
  - type: server
    id: server2
    brooklyn.config:
      bar: '$brooklyn:component("server1").config("MyParameter")'
      foo: '$brooklyn:parent().config("toplevelParam")'
```
