### PR TITLE
Fix template overrides - decorate `script` directive to prevent re-overriding of templates

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -152,7 +152,7 @@
 </div>
 
 <!-- QUICK INFO TEMPLATE :: START-->
-<script type="text/ng-template" id="blueprint-composer/component/catalog-selector/quick-info.html">
+<script type="text/ng-template" id="blueprint-composer/component/catalog-selector/quick-info.html" defer-to-preexisting-id="true">
     <div class="palette-item-quick-info">
         <div class="quick-info-title">{{ popover | entityName }}
             <br-svg type="close" class="pull-right closer" ng-click="closePopover()"></br-svg>

--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.html
@@ -62,7 +62,7 @@
 </div>
 
 <!--TYPEAHEAD TEMPLATE :: START-->
-<script type="text/ng-template" id="SuggestionTemplate.html">
+<script type="text/ng-template" id="SuggestionTemplate.html" defer-to-preexisting-id="true">
     <div class="dropdown-item">
         <span class="dropdown-item-value" ng-bind-html="match.model.value | uibTypeaheadHighlight:query"></span>
         <p class="dropdown-item-description" ng-if="match.model.description">{{ match.model.description }}</p>

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -36,7 +36,10 @@ const REPLACED_DSL_ENTITYSPEC = '___brooklyn:entitySpec';
 angular.module(MODULE_NAME, [onEnter, autoGrow, blurOnEnter, brooklynDslEditor, brooklynDslViewer])
     .directive('specEditor', ['$rootScope', '$templateCache', '$injector', '$sanitize', '$filter', '$log', '$sce', '$timeout', '$document', '$state', '$compile', 'blueprintService', 'composerOverrides', specEditorDirective])
     .filter('specEditorConfig', specEditorConfigFilter)
-    .filter('specEditorType', specEditorTypeFilter);
+    .filter('specEditorType', specEditorTypeFilter)
+    .run(['$templateCache', templateCache]);
+
+const TEMPLATE_URL = 'blueprint-composer/component/spec-editor/spec-editor.template.html';
 
 export default MODULE_NAME;
 
@@ -79,7 +82,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             model: '='
         },
         controller: ['$scope', '$element', controller],
-        template: template,
+        templateUrl: TEMPLATE_URL,
         link: link,
         controllerAs: 'specEditor',
     };
@@ -900,4 +903,8 @@ export function specEditorTypeFilter() {
             return item.miscData.get('typeName').indexOf(search) > -1 || item.type.indexOf(search) > -1;
         });
     }
+}
+
+function templateCache($templateCache) {
+    $templateCache.put(TEMPLATE_URL, template);
 }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -82,7 +82,9 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             model: '='
         },
         controller: ['$scope', '$element', controller],
-        templateUrl: TEMPLATE_URL,
+        templateUrl: function (tElement, tAttrs) { 
+            return tAttrs.templateUrl || TEMPLATE_URL; 
+        },
         link: link,
         controllerAs: 'specEditor',
     };

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -342,7 +342,7 @@
 
 <!-- ENTITY LOCATION -->
 <ng-include src="'blueprint-composer/component/spec-editor/section-locations.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-locations.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-locations.html" defer-to-preexisting-id="true">
   <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.location.open">
     <heading>
         Location
@@ -372,7 +372,7 @@
 
 <!-- ENTITY POLICIES -->
 <ng-include src="'blueprint-composer/component/spec-editor/section-policies.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-policies.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-policies.html" defer-to-preexisting-id="true">
   <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.policy.open">
     <heading>
         Policies
@@ -408,7 +408,7 @@
 
 <!-- ENTITY ENRICHERS -->
 <ng-include src="'blueprint-composer/component/spec-editor/section-enrichers.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-enrichers.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-enrichers.html" defer-to-preexisting-id="true">
   <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.enricher.open">
     <heading>
         Enrichers
@@ -443,12 +443,12 @@
 </script>
 
 <ng-include src="'blueprint-composer/component/spec-editor/section-others.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-others.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-others.html" defer-to-preexisting-id="true">
 </script>
 
 
 <!-- CONFIG INFO TEMPLATE :: START -->
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/config-info.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/config-info.html" defer-to-preexisting-id="true">
     <div class="config-item-quick-info">
         <div class="quick-info-metadata">
             <p><i class="mini-icon fa fa-fw fa-cog"></i> <samp class="type-symbolic-name">{{item.name}}</samp>
@@ -463,7 +463,7 @@
 <!-- CONFIG INFO TEMPLATE :: START-->
 
 <!-- SEARCH POLICY TEMPLATE :: START -->
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/search-policy.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/search-policy.html" defer-to-preexisting-id="true">
     <div ng-click="$event.stopPropagation(); $event.preventDefault();">
         <input ng-model="state.policy.search" type="text" class="form-control" placeholder="Search for a policy" auto-focus blur-on-enter />
     </div>
@@ -471,7 +471,7 @@
 <!--SEARCH POLICY TEMPLATE :: START-->
 
 <!-- SEARCH ENRICHER TEMPLATE :: START -->
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/search-enricher.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/search-enricher.html" defer-to-preexisting-id="true">
     <div ng-click="$event.stopPropagation(); $event.preventDefault();">
         <input ng-model="state.enricher.search" type="text" class="form-control" placeholder="Search for an enricher" auto-focus blur-on-enter />
     </div>
@@ -479,7 +479,7 @@
 <!--SEARCH ENRICHER TEMPLATE :: START-->
 
 <!--TYPEAHEAD TEMPLATE :: START-->
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/config-item.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/config-item.html" defer-to-preexisting-id="true">
     <div class="dropdown-item" ng-init="item = match.model">
         <div class="dropdown-row">
             <span ng-bind-html="match.model.name | uibTypeaheadHighlight:query" class="config-name"></span>
@@ -494,7 +494,7 @@
 <!--TYPEAHEAD TEMPLATE :: END-->
 
 <!--ADJUNCT TEMPLATE :: START-->
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/adjunct.html">
+<script type="text/ng-template" id="blueprint-composer/component/spec-editor/adjunct.html" defer-to-preexisting-id="true">
     <div class="media" ng-class="{'has-issues': adjunct.hasIssues()}">
         <div class="media-left media-middle">
             <img ng-src="{{adjunct.icon}}" alt="{{adjunct | entityName}} logo" class="media-object" />

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -69,13 +69,14 @@ import {graphicalEditDslState, dslParamLabelFilter} from "./views/main/graphical
 import bottomSheet from "brooklyn-ui-utils/bottom-sheet/bottom-sheet";
 import stackViewer from 'angular-java-stack-viewer';
 import {EntityFamily} from "./components/util/model/entity.model";
+import scriptTagDecorator from 'brooklyn-ui-utils/script-tag-non-overwrite/script-tag-non-overwrite';
 
 angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 'ui.router.state.events', brCore,
     brServerStatus, brAutoFocus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement,
     brYamlEditor, brUtils, brSpecEditor, brooklynCatalogSaver, brooklynApi, bottomSheet, stackViewer, brDragndrop,
     customActionDirective, customConfigSuggestionDropdown, paletteApiProvider, paletteServiceProvider, blueprintLoaderApiProvider,
     breadcrumbs, catalogSelector, designer, objectCache, entityFilters, locationFilter, actionService, blueprintService,
-    dslService, paletteDragAndDropService, recentlyUsedService])
+    dslService, paletteDragAndDropService, recentlyUsedService, scriptTagDecorator])
     .provider('composerOverrides', composerOverridesProvider)
     .filter('dslParamLabel', ['$filter', dslParamLabelFilter])
     .config(['$urlRouterProvider', '$stateProvider', '$logProvider', applicationConfig])

--- a/ui-modules/utils/script-tag-non-overwrite/script-tag-non-overwrite.js
+++ b/ui-modules/utils/script-tag-non-overwrite/script-tag-non-overwrite.js
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import angular from 'angular';
+
+/**
+ * If included, this decorates the default angular `<script>` tag so that it checks the
+ * template cache and does _not_ put the contents of the `script` into the cache if there
+ * is already an element with that ID present.
+ */
+
+const MODULE_NAME = 'brooklyn.components.script-tag-non-overwrite';
+
+angular.module(MODULE_NAME, [])
+    .decorator('scriptDirective', ['$delegate', '$templateCache', scriptTagDirectiveDecorator]);
+
+export default MODULE_NAME;
+
+const BROOKLYN_CONFIG = 'brooklyn.config';
+
+function scriptTagDirectiveDecorator($delegate, $templateCache) {
+    let base = $delegate[0];
+    return [ Object.assign({}, base, { compile: function(el, attr) {
+        let match = $templateCache.get(attr.id);
+        if (!(match === null || typeof match === 'undefined')) {
+            // no-op if this ID is already in the cache (e.g. manually overridden)
+            return function() {};
+        }
+        // otherwise do default behaviour
+        return base.compile(el, attr);
+    } }) ];
+}

--- a/ui-modules/utils/script-tag-non-overwrite/script-tag-non-overwrite.js
+++ b/ui-modules/utils/script-tag-non-overwrite/script-tag-non-overwrite.js
@@ -20,9 +20,16 @@
 import angular from 'angular';
 
 /**
- * If included, this decorates the default angular `<script>` tag so that it checks the
- * template cache and does _not_ put the contents of the `script` into the cache if there
- * is already an element with that ID present.
+ * If included, this decorates the default angular `<script>` tag so that it if a
+ * 'defer-to-preexisting-id' attribute is set, it will check the template cache and 
+ * skip putting the contents of the `script` into the cache if there is already an 
+ * element with that ID present.
+ *
+ * This allows us to include `<script type="ng-template" id="..." defer-to-preexisting-id="true">` blocks 
+ * in HTML templates that work in the usual way, but with the extra "defer" attribute we can allow
+ * the template to be overridden by a `run` block (or other block) installing a custom HTML template
+ * under the same ID.  (By default the `script` directive will always install the ID, on every
+ * directive processing on the template, meaning one cannot easily override the template.) 
  */
 
 const MODULE_NAME = 'brooklyn.components.script-tag-non-overwrite';
@@ -38,7 +45,7 @@ function scriptTagDirectiveDecorator($delegate, $templateCache) {
     let base = $delegate[0];
     return [ Object.assign({}, base, { compile: function(el, attr) {
         let match = $templateCache.get(attr.id);
-        if (!(match === null || typeof match === 'undefined')) {
+        if (attr.deferToPreexistingId && !(match === null || typeof match === 'undefined')) {
             // no-op if this ID is already in the cache (e.g. manually overridden)
             return function() {};
         }


### PR DESCRIPTION
by default `<script>` will install to template cache whenever it is processed as a directive.
this decorates it to be no-op if there is already something in the cache with that name,
allowing programmatic overrides of templates configured using `<script id="...">` notation.