### PR TITLE
Separate function of left and right panels

### DIFF
--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -81,7 +81,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         scope: {
             model: '='
         },
-        controller: ['$scope', '$element', controller],
+        controller: ['$scope', '$element', 'paletteService', controller],
         templateUrl: function (tElement, tAttrs) { 
             return tAttrs.templateUrl || TEMPLATE_URL; 
         },
@@ -89,7 +89,8 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         controllerAs: 'specEditor',
     };
 
-    function controller($scope, $element) {
+    function controller($scope, $element, paletteService) {
+        $scope.paletteService = paletteService;
         (composerOverrides.configureSpecEditorController || function() {})(this, $scope, $element);
         
         // does very little currently, but link adds to this
@@ -102,6 +103,19 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         scope.FAMILIES = EntityFamily;
         scope.RESERVED_KEYS = RESERVED_KEYS;
         scope.REPLACED_DSL_ENTITYSPEC = REPLACED_DSL_ENTITYSPEC;
+
+        specEditor.sections = scope.paletteService.getSections();
+        specEditor.hasParentEntity = element.parent().children()[0].tagName == "SECTION"
+            && element.parent().children()[0].classList.contains("spec-parent");
+        specEditor.needToolbar = !["policy", "enricher", "location", "other"].includes(element.attr("model"));
+
+        if (specEditor.hasParentEntity) {
+            $rootScope.oldSelectedSection = $rootScope.selectedSection
+            $rootScope.selectedSection = specEditor.sections.entities;
+        } else if ($rootScope.oldSelectedSection) {
+            $rootScope.selectedSection = $rootScope.oldSelectedSection;
+            $rootScope.oldSelectedSection = undefined;
+        }
 
         let defaultState = {
             config: {

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -27,8 +27,14 @@
 
 spec-editor {
   display: block;
-  margin-top: 15px;
   color: @gray;
+
+  .config-panel {
+    padding: 20px 15px;
+    flex-basis: 100%;
+    border-right: 1px solid @navbar-default-border;
+    min-width: 0;
+  }
 
   .toolbar-button-affordance() {
     color: mix(@gray, @gray-lighter);
@@ -76,6 +82,7 @@ spec-editor {
 
   .panel-header-body {
     padding-left: 2em;
+    width: initial;
     .panel-header-icon {
       width: 30px;
       margin-left: -30px;
@@ -196,6 +203,66 @@ spec-editor {
       .spec-actions {
         flex-grow: 0;
       }
+      h2 {
+        margin-bottom: 0px;
+        input {
+          color: @gray-light;
+        }
+      }
+      .btn-group {
+        display: flex;
+        align-items: center;
+
+        & br-svg {
+          display: block;
+          height: 20px;
+          width: 20px;
+          cursor: pointer;
+        }
+
+        .fa-bars {
+          font-size: 20px;
+        }
+      }
+    }
+
+    .media {
+      display: flex;
+
+      .panel-header-body {
+        min-width: 0;
+        padding-left: 0;
+
+        div {
+          display: flex;
+        }
+
+        .fa-bookmark {
+          display: block;
+          min-width: 28px;
+          margin-left: 0;
+        }
+
+        .fa-id-card-o {
+          margin-left: 0;
+          margin-right: 0;
+        }
+
+        .entity-type-header {
+          text-overflow: ellipsis;
+          overflow: hidden;
+          display: block;
+        }
+
+        .version {
+          margin-left: 28px;
+        }
+
+        .identifier {
+          margin-top: 0;
+          align-items: center;
+        }
+      }
     }
 
     .spec-actions {
@@ -212,6 +279,26 @@ spec-editor {
     }
     .spec-title {
       margin-top: 0;
+    }
+  }
+
+  .core-config-panel {
+    margin-top: 20px;
+
+    > div:first-child {
+      display:flex;
+      align-items: center;
+
+      div:first-child {
+        color: @gray-light;
+        font-size: 16px;
+      }
+      span {
+        margin-left: 6px;
+      }
+      div:last-child {
+        margin-left: auto;
+      }
     }
   }
 
@@ -856,4 +943,11 @@ dsl-viewer {
     a {
         cursor: alias;
     }
+}
+
+.pane-configuration .pane-palette {
+  width: initial;
+  left: initial;
+  border-left: initial;
+  box-shadow: initial;
 }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -17,141 +17,151 @@
   under the License.
 -->
 <!-- ENTITY TYPE -->
-<section class="spec-type container-fluid panel-group">
-  <div class="panel">
-    <div class="spec-type-header">
-        <h2 class="spec-title"><input class="form-control editable" ng-model="model.name" placeholder="{{model.miscData.get('typeName') || 'Unnamed ' + (!model.hasParent() ? 'application' : model.family.displayName)}}" blur-on-enter /></h2>
+<div class="layout">
+    <div class="config-panel" ng-if="$root.selectedSection">
+        <section class="spec-type container-fluid panel-group">
+            <div class="panel">
 
-        <div class="btn-group pull-right spec-actions" ng-if="model.hasType()" uib-dropdown>
-            <button id="spec-actions" type="button" class="btn btn-link" uib-dropdown-toggle>
-                <span class="fa fa-bars"></span>
-            </button>
-            <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="spec-actions">
-                <li role="menuitem"><a ng-href="/brooklyn-ui-catalog/#!/bundles/{{model.miscData.get('bundle').symbolicName}}/{{model.miscData.get('bundle').version}}/types/{{model.type}}/{{model.version || 'latest'}}" target="_blank">Open in Catalog</a></li>
-                <li role="separator" class="divider"></li>
-                <li role="menuitem"><a href ng-click="removeModel()"><span class="text-danger">Delete</span></a></li>
-            </ul>
-        </div>
-    </div>
+                <div class="spec-type-header">
+                    <h2 class="spec-title">
+                        <input class="form-control editable" ng-model="model.name" placeholder="{{model.miscData.get('typeName') || 'Unnamed ' + (!model.hasParent() ? 'application' : model.family.displayName)}}" blur-on-enter/>
+                    </h2>
 
-    <p ng-if="!model.hasParent()"><input class="form-control editable spec-id" ng-model="model.id" placeholder="No reference ID" blur-on-enter /></p>
-
-    <div class="media" ng-if="model.hasParent()">
-        <div class="media-left">
-            <img ng-src="{{model.icon}}" alt="{{model | entityName}} logo" class="media-object" />
-        </div>
-        <div class="media-body panel-header-body">
-            <div title="{{ model.miscData.get('typeName') }}"><i class="fa fa-bookmark panel-header-icon"></i><samp class="entity-type-header">{{model.type}}</samp> <span class="label label-primary version">{{model | entityVersion}}</span></div>
-            <div ng-if="['POLICY', 'ENRICHER'].indexOf(model.family.id) === -1" class="identifier">
-                <i class="fa fa-id-card-o panel-header-icon"></i>
-                <input class="form-control editable" ng-model="model.id" placeholder="(no reference ID)" blur-on-enter />
-                </div>
-        </div>
-    </div>
-  </div>
-</section>
-
-<!-- ENTITY CONFIGURATION -->
-<br-collapsible ng-if="true" state="state.config.open">  <!-- the ng-if is needed to make state update?! -->
-    <heading>
-        Configuration
-        <span ng-if="getConfigIssues().length> 0" class="badge" ng-class="getBadgeClass(getConfigIssues())">{{getConfigIssues().length}}</span>
-        <span class="pull-right" ng-show="$parent.stateWrapped.state">
-            <span class="spec-toolbar-action" ng-class="{'active': state.config.filter.open}"><i class="fa fa-filter collapsible-action" title="Filter configuration" ng-click="$event.stopPropagation(); $event.preventDefault(); state.config.filter.open = !state.config.filter.open" ng-class="{'text-info': state.config.search.length > 0}"></i></span>
-            <span class="spec-toolbar-action"><i class="fa fa-plus collapsible-action" title="Add configuration" ng-click="$event.stopPropagation(); $event.preventDefault(); state.config.add.open = !state.config.add.open"></i></span>
-        </span>
-    </heading>
-
-    <fieldset uib-collapse="!state.config.filter.open" class="spec-configuration-filters">
-        <div class="form-group">
-            <input ng-model="state.config.search" type="text" class="form-control" placeholder="Search for config key by name" auto-focus="state.config.filter.open" blur-on-enter />
-        </div>
-        <div class="form-group">
-            <ul class="spec-configuration-filters-categories">
-                <li ng-repeat="filter in filters.config track by filter.id"
-                    ng-class="{ 'disabled': isFilterDisabled(filter) }"
-                    ng-click="onFilterClicked(filter)"
-                    class="pull-left">
-                    <i class="filter-checkbox fa" ng-class="{'fa-check-square-o': state.config.filter.values[ filter.id ], 'fa-square-o': !state.config.filter.values[ filter.id ]}"></i> {{filter.label}}
-                </li>
-            </ul>
-        </div>
-    </fieldset>
-
-    <fieldset uib-collapse="!state.config.add.open" class="spec-configuration-add">
-        <input auto-focus="state.config.add.open"
-             type="text"
-             autocomplete="off"
-             ng-model="state.config.add.value"
-             placeholder="Add a new configuration key or open existing"
-             class="form-control"
-             uib-typeahead="config.name for config in state.config.add.list | filter:{name:$viewValue}"
-             typeahead-template-url="blueprint-composer/component/spec-editor/config-item.html"
-             typeahead-editable="true"
-             typeahead-show-hint="true"
-             typeahead-min-length="0"
-             typeahead-select-on-blur="true"
-             typeahead-on-select="onFocusOnConfig($item, $model, $label, $event)"
-             typeahead-no-results="noResults"
-             blur-on-enter />
-
-        <div ng-if="state.config.add.value.length > 0 && noResults" uib-dropdown uib-dropdown-toggle auto-close="disabled" is-open="true">
-            <ul class="dropdown-menu">
-                <!-- mimic real dropdown if nothing found -->
-                <li class="uib-typeahead-match"><a ng-click="addConfigKey()">
-                    <div class="dropdown-item" ng-init="item = match.model">
-                        <div class="dropdown-row">
-                        <span ng-bind-html="state.config.add.value | uibTypeaheadHighlight:query" class="config-name"></span>
-                        <i class="fa fa-fw fa-plus-square-o"></i>
+                    <div class="btn-group pull-right spec-actions" uib-dropdown>
+                        <button id="spec-actions" type="button" class="btn btn-link" ng-if="model.hasType()" uib-dropdown-toggle>
+                            <span class="fa fa-bars"></span>
+                        </button>
+                        <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="spec-actions" ng-if="model.hasType()">
+                            <li role="menuitem"><a ng-href="/brooklyn-ui-catalog/#!/bundles/{{model.miscData.get('bundle').symbolicName}}/{{model.miscData.get('bundle').version}}/types/{{model.type}}/{{model.version || 'latest'}}" target="_blank">Open in Catalog</a></li>
+                            <li role="separator" class="divider"></li>
+                            <li role="menuitem"><a href ng-click="removeModel()"><span class="text-danger">Delete</span></a></li>
+                        </ul>
+                        <br-svg type="close" ng-if="!specEditor.hasParentEntity" ng-click="$root.selectedSection = undefined"></br-svg>
                     </div>
-                </a></li>
-            </ul>
-        </div>
-    </fieldset>
+                </div>
 
-    <div class="spec-configuration">
-        <div class="spec-empty-state" ng-if="filteredItems.length === 0">
-          <div ng-if="model.miscData.get('config').length === 0">
-            <h4>No configuration</h4>
-          </div>
-          <div ng-if="model.miscData.get('config').length > 0">
-            <h4>No matching configuration</h4>
-            <p class="buttons">
-                <button class="btn btn-sm btn-default" ng-if="state.config.search.length > 0" ng-click="state.config.search = ''">Clear search</button>
-                <button class="btn btn-sm btn-success" ng-if="!state.config.filter.values.all" ng-click="state.config.filter.values.all = true">
-                    <i class="fa fa-filter"></i> Display all config options
-                </button>
-            </p>
-          </div>
-        </div>
+                <p ng-if="!model.hasParent()"><input class="form-control editable spec-id" ng-model="model.id" placeholder="No reference ID" blur-on-enter/></p>
 
-        <form name="formSpecConfig" novalidate class="lightweight">
-            <div ng-repeat="item in (filteredItems = (model.miscData.get('config') | specEditorConfig:state.config.filter.values:model | filter:{name:state.config.search} | orderBy:+priority)) track by item.name ">
-                <div class="form-group" ng-class="{'has-error': (model.issues | filter:{ref: item.name}:true).length > 0, 'used': config[item.name] !== undefined}" 
-                        ng-switch="getConfigWidgetMode(item)" 
-                        tabindex="1"
-                        auto-focus="state.config.focus === item.name"
-                        auto-focus-listen-to-window="true"
-                        auto-focus-not-if-within="true"
-                        ng-focus="specEditor.recordFocus(item)"
-                        on-enter="specEditor.advanceControlInFormGroup">
-                  <div ng-if="specEditor.getCustomConfigWidgetMode(item) === 'enabled'" class="custom-config-widget">
-                    <ng-include src="specEditor.getCustomConfigWidgetTemplate(item)" class="custom-config-widget"/>
-                  </div>
-                  
-                  <!-- have to hide it; excluding it conditionally via if doesn't play nice with switch -->
-                  <div ng-show="specEditor.getCustomConfigWidgetMode(item) !== 'enabled'" class="config-flex-row">
-                    <label class="control-label" for="{{item.name}}">
-                        <span class="label-spec-configuration">{{item.label || item.name}}</span>
-                        <span class="info-spec-configuration">
+                <div class="media" ng-if="model.hasParent()">
+                    <div class="media-left">
+                        <img ng-src="{{model.icon}}" alt="{{model | entityName}} logo" class="media-object"/>
+                    </div>
+                    <div class="panel-header-body">
+                        <div title="{{model.type}}"><i class="fa fa-bookmark panel-header-icon"></i><samp class="entity-type-header">{{model.type}}</samp></div>
+                        <span class="label label-primary version">{{model | entityVersion}}</span>
+                        <div ng-if="['POLICY', 'ENRICHER'].indexOf(model.family.id) === -1" class="identifier">
+                            <i class="fa fa-id-card-o panel-header-icon"></i>
+                            <input class="form-control editable" ng-model="model.id" placeholder="(no reference ID)" blur-on-enter/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- ENTITY CONFIGURATION -->
+        <div class="core-config-panel" ng-if="$root.selectedSection.type.id === 'ENTITY'" state="state.config.open">  <!-- the ng-if is needed to make state update?! -->
+            <div>
+                <div>Configuration</div>
+                <span ng-if="getConfigIssues().length> 0" class="badge" ng-class="getBadgeClass(getConfigIssues())">{{getConfigIssues().length}}</span>
+                <div>
+            <span class="spec-toolbar-action" ng-class="{'active': state.config.filter.open}"><i class="fa fa-filter collapsible-action" title="Filter configuration" ng-click="$event.stopPropagation(); $event.preventDefault(); state.config.filter.open = !state.config.filter.open"
+                                                                                                 ng-class="{'text-info': state.config.search.length > 0}"></i></span>
+                    <span class="spec-toolbar-action"><i class="fa fa-plus collapsible-action" title="Add configuration" ng-click="$event.stopPropagation(); $event.preventDefault(); state.config.add.open = !state.config.add.open"></i></span>
+
+        </div>
+            </div>
+
+            <fieldset uib-collapse="!state.config.filter.open" class="spec-configuration-filters">
+                <div class="form-group">
+                    <input ng-model="state.config.search" type="text" class="form-control" placeholder="Search for config key by name" auto-focus="state.config.filter.open" blur-on-enter/>
+                </div>
+                <div class="form-group">
+                    <ul class="spec-configuration-filters-categories">
+                        <li ng-repeat="filter in filters.config track by filter.id"
+                            ng-class="{ 'disabled': isFilterDisabled(filter) }"
+                            ng-click="onFilterClicked(filter)"
+                            class="pull-left">
+                            <i class="filter-checkbox fa" ng-class="{'fa-check-square-o': state.config.filter.values[ filter.id ], 'fa-square-o': !state.config.filter.values[ filter.id ]}"></i> {{filter.label}}
+                        </li>
+                    </ul>
+                </div>
+            </fieldset>
+
+            <fieldset uib-collapse="!state.config.add.open" class="spec-configuration-add">
+                <input auto-focus="state.config.add.open"
+                       type="text"
+                       autocomplete="off"
+                       ng-model="state.config.add.value"
+                       placeholder="Add a new configuration key or open existing"
+                       class="form-control"
+                       uib-typeahead="config.name for config in state.config.add.list | filter:{name:$viewValue}"
+                       typeahead-template-url="blueprint-composer/component/spec-editor/config-item.html"
+                       typeahead-editable="true"
+                       typeahead-show-hint="true"
+                       typeahead-min-length="0"
+                       typeahead-select-on-blur="true"
+                       typeahead-on-select="onFocusOnConfig($item, $model, $label, $event)"
+                       typeahead-no-results="noResults"
+                       blur-on-enter/>
+
+                <div ng-if="state.config.add.value.length > 0 && noResults" uib-dropdown uib-dropdown-toggle auto-close="disabled" is-open="true">
+                    <ul class="dropdown-menu">
+                        <!-- mimic real dropdown if nothing found -->
+                        <li class="uib-typeahead-match"><a ng-click="addConfigKey()">
+                            <div class="dropdown-item" ng-init="item = match.model">
+                                <div class="dropdown-row">
+                                    <span ng-bind-html="state.config.add.value | uibTypeaheadHighlight:query" class="config-name"></span>
+                                    <i class="fa fa-fw fa-plus-square-o"></i>
+                                </div>
+                            </div>
+                        </a></li>
+                    </ul>
+                </div>
+            </fieldset>
+
+            <div class="spec-configuration">
+                <div class="spec-empty-state" ng-if="filteredItems.length === 0">
+                    <div ng-if="model.miscData.get('config').length === 0">
+                        <h4>No configuration</h4>
+                    </div>
+                    <div ng-if="model.miscData.get('config').length > 0">
+                        <h4>No matching configuration</h4>
+                        <p class="buttons">
+                            <button class="btn btn-sm btn-default" ng-if="state.config.search.length > 0" ng-click="state.config.search = ''">Clear search</button>
+                            <button class="btn btn-sm btn-success" ng-if="!state.config.filter.values.all" ng-click="state.config.filter.values.all = true">
+                                <i class="fa fa-filter"></i> Display all config options
+                            </button>
+                        </p>
+                    </div>
+                </div>
+
+                <form name="formSpecConfig" novalidate class="lightweight">
+                    <div ng-repeat="item in (filteredItems = (model.miscData.get('config') | specEditorConfig:state.config.filter.values:model | filter:{name:state.config.search} | orderBy:+priority)) track by item.name ">
+                        <div class="form-group" ng-class="{'has-error': (model.issues | filter:{ref: item.name}:true).length > 0, 'used': config[item.name] !== undefined}"
+                             ng-switch="getConfigWidgetMode(item)"
+                             tabindex="1"
+                             auto-focus="state.config.focus === item.name"
+                             auto-focus-listen-to-window="true"
+                             auto-focus-not-if-within="true"
+                             ng-focus="specEditor.recordFocus(item)"
+                             on-enter="specEditor.advanceControlInFormGroup">
+                            <div ng-if="specEditor.getCustomConfigWidgetMode(item) === 'enabled'" class="custom-config-widget">
+                                <ng-include src="specEditor.getCustomConfigWidgetTemplate(item)" class="custom-config-widget"/>
+                            </div>
+
+                            <!-- have to hide it; excluding it conditionally via if doesn't play nice with switch -->
+                            <div ng-show="specEditor.getCustomConfigWidgetMode(item) !== 'enabled'" class="config-flex-row">
+                                <label class="control-label" for="{{item.name}}">
+                                    <span class="label-spec-configuration">{{item.label || item.name}}</span>
+                                    <span class="info-spec-configuration">
                            <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
-                               popover-title="{{item.label || item.name}}"
-                               uib-popover-template="'blueprint-composer/component/spec-editor/config-info.html'"
-                               popover-class="spec-editor-popover" popover-placement="top-left" popover-append-to-body="true"></i>
+                              popover-title="{{item.label || item.name}}"
+                              uib-popover-template="'blueprint-composer/component/spec-editor/config-info.html'"
+                              popover-class="spec-editor-popover" popover-placement="top-left" popover-append-to-body="true"></i>
                         </span>
-                    </label>
-                    
-                    <span class="label-rhs-buttons">
+                                </label>
+
+                                <span class="label-rhs-buttons">
                         <span class="spacer"> </span>
                         <span class="custom-widget-enable-button" ng-if="specEditor.getCustomConfigWidgetMode(item) !== null">
                             <i class="fa fa-fw fa-sun-o" ng-click="specEditor.toggleCustomConfigWidgetMode(item)" aria-hidden="true" title="{{specEditor.getCustomConfigWidgetModeTitle(item)}} [{{item.name}}]"></i>
@@ -176,296 +186,299 @@
                             <span class="sr-only">Clear configuration [{{item.name}}]</span>
                         </span>
                     </span>
-                    
-                    <div class="control-value" ng-class="{ 'inline-control': item.widgetMode==='boolean', 'unset': !defined(config[item.name]), 'has-default': defined(item.defaultValue) && item.defaultValue!=null, 'code-mode-active': state.config.codeModeActive[item.name] }">
-                        <div ng-switch-when="boolean" class="boolean">
-                            <div class="btn-group btn-block" role="group">
-                                <button type="button" class="btn btn-xs btn-default" ng-class="{'btn-success active': config[item.name] === false, 'active': config[item.name] === undefined && item.defaultValue === false}" ng-click="config[item.name] = false" ng-focus="specEditor.recordFocus(item)">false</button>
-                                <button type="button" class="btn btn-xs btn-default" ng-class="{'btn-success active': config[item.name] === true, 'active': config[item.name] === undefined && item.defaultValue === true}" ng-click="config[item.name] = true" ng-focus="specEditor.recordFocus(item)">true</button>
-                                <span class="input-group-btn dsl-wizard-button" ng-if="specEditor.isDslWizardButtonAllowed(item.name)">
-                                    <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name})" class="btn btn-xs btn-default" ng-class="{'btn-success active': config[item.name].length > 0}" title="Open in DSL editor" ng-focus="specEditor.recordFocus(item)"><i class="fa fa-bolt"></i></a>
-                                </span>
-                            </div>
-                        </div>
 
-                        <span class="main-control span-for-rounded-edge">
+                                <div class="control-value" ng-class="{ 'inline-control': item.widgetMode==='boolean', 'unset': !defined(config[item.name]), 'has-default': defined(item.defaultValue) && item.defaultValue!=null, 'code-mode-active': state.config.codeModeActive[item.name] }">
+                                    <div ng-switch-when="boolean" class="boolean">
+                                        <div class="btn-group btn-block" role="group">
+                                            <button type="button" class="btn btn-xs btn-default" ng-class="{'btn-success active': config[item.name] === false, 'active': config[item.name] === undefined && item.defaultValue === false}" ng-click="config[item.name] = false"
+                                                    ng-focus="specEditor.recordFocus(item)">false
+                                            </button>
+                                            <button type="button" class="btn btn-xs btn-default" ng-class="{'btn-success active': config[item.name] === true, 'active': config[item.name] === undefined && item.defaultValue === true}" ng-click="config[item.name] = true"
+                                                    ng-focus="specEditor.recordFocus(item)">true
+                                            </button>
+                                            <span class="input-group-btn dsl-wizard-button" ng-if="specEditor.isDslWizardButtonAllowed(item.name)">
+                                                <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name})" class="btn btn-xs btn-default" ng-class="{'btn-success active': config[item.name].length > 0}" title="Open in DSL editor" ng-focus="specEditor.recordFocus(item)"><i class="fa fa-bolt"></i></a>
+                                            </span>
+                                        </div>
+                                    </div>
+
+                                    <span class="main-control span-for-rounded-edge">
                             <select ng-switch-when="java.lang.Enum"
-                                ng-model="config[item.name]"
-                                ng-options="s.value as (s.description + (item.defaultValue === s.value ? ' --- default' : '')) for s in item.possibleValues"
-                                ng-focus="specEditor.recordFocus(item)"
-                                class="form-control rounded-edge"
-                                name="{{item.name}}"
-                                id="{{item.name}}"></select>
+                                    ng-model="config[item.name]"
+                                    ng-options="s.value as (s.description + (item.defaultValue === s.value ? ' --- default' : '')) for s in item.possibleValues"
+                                    ng-focus="specEditor.recordFocus(item)"
+                                    class="form-control rounded-edge"
+                                    name="{{item.name}}"
+                                    id="{{item.name}}"></select>
                         </span>
 
-                        <div ng-switch-when="map" 
-                                ng-init="expandMode = 'default'" class="collection"
-                                ng-class="{ 'open-when-unfocused': expandMode=='open' }">
-                            <p class="collection-toggle" ng-click="expandMode = cycleExpandMode(expandMode, 'map', item, state)" ng-focus="specEditor.recordFocus(item)"
-                                    ng-class="{ 'has-default': item.defaultValue && getObjectSize(item.defaultValue) }">
-                                <i class="fa collection-caret" ng-class="{'fa-caret-square-o-down': expandMode=='closed', 'fa-caret-square-o-up': expandMode=='open', 'caret-default': expandMode=='default' }" aria-hidden="true" title="{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} map"></i>
-                                <span class="sr-only">{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} map</span>
-                                <ng-pluralize count="getObjectSize(config[item.name])"
-                                              when="{'0': 'No entries',
+                                    <div ng-switch-when="map"
+                                         ng-init="expandMode = 'default'" class="collection"
+                                         ng-class="{ 'open-when-unfocused': expandMode=='open' }">
+                                        <p class="collection-toggle" ng-click="expandMode = cycleExpandMode(expandMode, 'map', item, state)" ng-focus="specEditor.recordFocus(item)"
+                                           ng-class="{ 'has-default': item.defaultValue && getObjectSize(item.defaultValue) }">
+                                            <i class="fa collection-caret" ng-class="{'fa-caret-square-o-down': expandMode=='closed', 'fa-caret-square-o-up': expandMode=='open', 'caret-default': expandMode=='default' }" aria-hidden="true"
+                                               title="{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} map"></i>
+                                            <span class="sr-only">{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} map</span>
+                                            <ng-pluralize count="getObjectSize(config[item.name])"
+                                                          when="{'0': 'No entries',
                                             'one': '{} entry',
                                             'other': '{} entries'}"></ng-pluralize>
-                                <span ng-if="!defined(config[item.name]) && getObjectSize(item.defaultValue)">
+                                            <span ng-if="!defined(config[item.name]) && getObjectSize(item.defaultValue)">
                                     (default <ng-pluralize count="getObjectSize(item.defaultValue)"
-                                              when="{'0': 'no entries',
+                                                           when="{'0': 'no entries',
                                         'one': '{} entry',
                                         'other': '{} entries'}"></ng-pluralize>)
                                 </span>
-                            </p>
-                            <ul class="collection-map" 
-                                    ng-class="{'default-collapse': expandMode=='default', 'collapse': expandMode=='closed'}">
-                                <li ng-repeat="(mapKey, mapValue) in config[item.name] track by mapKey" class="collection-item">
+                                        </p>
+                                        <ul class="collection-map"
+                                            ng-class="{'default-collapse': expandMode=='default', 'collapse': expandMode=='closed'}">
+                                            <li ng-repeat="(mapKey, mapValue) in config[item.name] track by mapKey" class="collection-item">
                                     <span class="collection-item-shrink collection-map-key">
                                         <i ng-click="onDeleteMapProperty(config[item.name], mapKey)" class="fa fa-fw fa-times remove-spec-configuration" aria-hidden="true" title="Remove property [{{mapKey}}]"></i>
                                         <span class="sr-only">Remove property [{{mapKey}}]</span>
                                         {{mapKey}}
                                     </span>
-                                    <div class="collection-item-grow">
+                                                <div class="collection-item-grow">
                                         <span class="input-group">
                                             <span class="main-control span-for-rounded-edge">
-                                                <input type="text" ng-model="config[item.name][mapKey]" class="form-control rounded-edge" placeholder="(empty)" 
-                                                    ng-focus="specEditor.recordFocus(item)"
-                                                    on-enter="specEditor.advanceControlInFormGroup" />
+                                                <input type="text" ng-model="config[item.name][mapKey]" class="form-control rounded-edge" placeholder="(empty)"
+                                                       ng-focus="specEditor.recordFocus(item)"
+                                                       on-enter="specEditor.advanceControlInFormGroup"/>
                                             </span>
                                             <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name, mapKey)">
                                                 <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name, index: mapKey})" class="btn btn-default" title="Open in DSL editor"><i class="fa fa-bolt"></i></a>
                                             </span>
                                         </span>
-                                    </div>
-                                </li>
-                                <li class="collection-item collection-add input-group" ng-class="{'nonempty': nonempty(config[item.name])}">
+                                                </div>
+                                            </li>
+                                            <li class="collection-item collection-add input-group" ng-class="{'nonempty': nonempty(config[item.name])}">
                                     <span class="main-control span-for-rounded-edge">
-                                      <input ng-model="newKey" type="text" placeholder="Add property key" class="form-control rounded-edge" 
-                                        ng-focus="specEditor.recordFocus(item)"
-                                        on-enter="specEditor.advanceOutToFormGroupInPanel" ng-blur="onAddMapProperty(item.name, newKey, $event); newKey = '';" required />
+                                      <input ng-model="newKey" type="text" placeholder="Add property key" class="form-control rounded-edge"
+                                             ng-focus="specEditor.recordFocus(item)"
+                                             on-enter="specEditor.advanceOutToFormGroupInPanel" ng-blur="onAddMapProperty(item.name, newKey, $event); newKey = '';" required/>
                                     </span>
-                                    <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name, null, newKey)">
+                                                <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name, null, newKey)">
                                         <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name})" class="btn btn-default" title="Open in DSL editor"><i class="fa fa-bolt"></i></a>
                                     </span>
-                                </li>
-                            </ul>
-                        </div>
+                                            </li>
+                                        </ul>
+                                    </div>
 
-                        <div ng-switch-when="array" ng-switch-when-separator="|" 
-                                ng-init="expandMode = 'default'" class="collection"
-                                ng-class="{ 'open-when-unfocused': expandMode=='open' }">
-                            <p class="collection-toggle" ng-click="expandMode = cycleExpandMode(expandMode, 'map', item, state)" ng-focus="specEditor.recordFocus(item)"
-                                    ng-class="{ 'has-default': item.defaultValue && item.defaultValue.length }">
-                                <i class="fa collection-caret" ng-class="{'fa-caret-square-o-down': expandMode=='closed', 'fa-caret-square-o-up': expandMode=='open', 'caret-default': expandMode=='default' }" aria-hidden="true" title="{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} list"></i>
-                                <span class="sr-only">{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} list</span>
-                                <ng-pluralize count="config[item.name] ? config[item.name].length : 0"
-                                              when="{'0': 'No entries',
+                                    <div ng-switch-when="array" ng-switch-when-separator="|"
+                                         ng-init="expandMode = 'default'" class="collection"
+                                         ng-class="{ 'open-when-unfocused': expandMode=='open' }">
+                                        <p class="collection-toggle" ng-click="expandMode = cycleExpandMode(expandMode, 'map', item, state)" ng-focus="specEditor.recordFocus(item)"
+                                           ng-class="{ 'has-default': item.defaultValue && item.defaultValue.length }">
+                                            <i class="fa collection-caret" ng-class="{'fa-caret-square-o-down': expandMode=='closed', 'fa-caret-square-o-up': expandMode=='open', 'caret-default': expandMode=='default' }" aria-hidden="true"
+                                               title="{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} list"></i>
+                                            <span class="sr-only">{{expandMode=='closed' ? 'Unpin' : expandMode=='open' ? 'Close (pin)' : 'Open (pin)'}} list</span>
+                                            <ng-pluralize count="config[item.name] ? config[item.name].length : 0"
+                                                          when="{'0': 'No entries',
                                         'one': '{} entry',
                                         'other': '{} entries'}"></ng-pluralize>
-                                <span ng-if="!defined(config[item.name]) && item.defaultValue && item.defaultValue.length">
+                                            <span ng-if="!defined(config[item.name]) && item.defaultValue && item.defaultValue.length">
                                     (default <ng-pluralize count="item.defaultValue.length"
-                                              when="{'0': 'no entries',
+                                                           when="{'0': 'no entries',
                                         'one': '{} entry',
                                         'other': '{} entries'}"></ng-pluralize>)
                                 </span>
-                            </p>
-                            <ul class="collection-list"
-                                    ng-class="{'default-collapse': expandMode=='default', 'collapse': expandMode=='closed'}">
-                                <li ng-repeat="value in config[item.name] track by $index" class="collection-item">
+                                        </p>
+                                        <ul class="collection-list"
+                                            ng-class="{'default-collapse': expandMode=='default', 'collapse': expandMode=='closed'}">
+                                            <li ng-repeat="value in config[item.name] track by $index" class="collection-item">
                                     <span class="collection-item-shrink">
                                         <i ng-click="onDeleteListItem(config[item.name], $index)" class="fa fa-fw fa-times remove-spec-configuration" aria-hidden="true" title="Remove item [{{value}}]"></i>
                                         <span class="sr-only">Remove item [{{value}}]</span>
                                     </span>
-                                    <div class="collection-item-grow">
+                                                <div class="collection-item-grow">
                                         <span class="input-group">
                                             <span class="main-control span-for-rounded-edge">
-                                                <input type="text" ng-model="config[item.name][$index]" class="form-control rounded-edge" placeholder="(empty)" 
-                                                    ng-focus="specEditor.recordFocus(item)"
-                                                    on-enter="specEditor.advanceControlInFormGroup" />
+                                                <input type="text" ng-model="config[item.name][$index]" class="form-control rounded-edge" placeholder="(empty)"
+                                                       ng-focus="specEditor.recordFocus(item)"
+                                                       on-enter="specEditor.advanceControlInFormGroup"/>
                                             </span>
                                             <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name, $index)" ng-focus="specEditor.recordFocus(item)">
                                                 <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name, index: $index})" class="btn btn-default" title="Open in DSL editor"><i class="fa fa-bolt"></i></a>
                                             </span>
                                         </span>
-                                    </div>
-                                </li>
-                                <li class="collection-item collection-add input-group" ng-class="{'nonempty': config[item.name].length>0}">
+                                                </div>
+                                            </li>
+                                            <li class="collection-item collection-add input-group" ng-class="{'nonempty': config[item.name].length>0}">
                                     <span class="input-group">
                                         <span class="main-control span-for-rounded-edge">
-                                          <input ng-model="newItem" type="text" placeholder="Add item" class="form-control rounded-edge" auto-focus="expandMode != 'closed'" 
-                                            ng-focus="specEditor.recordFocus(item)"
-                                            on-enter="specEditor.advanceOutToFormGroupInPanel" ng-blur="onAddListItem(item.name, newItem, $event, $element); newItem = '';" required />
+                                          <input ng-model="newItem" type="text" placeholder="Add item" class="form-control rounded-edge" auto-focus="expandMode != 'closed'"
+                                                 ng-focus="specEditor.recordFocus(item)"
+                                                 on-enter="specEditor.advanceOutToFormGroupInPanel" ng-blur="onAddListItem(item.name, newItem, $event, $element); newItem = '';" required/>
                                         </span>
                                         <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name, -1, newItem)">
                                             <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name, index: config[item.name].length})" class="btn btn-default" title="Open in DSL editor"><i class="fa fa-bolt"></i></a>
                                         </span>
                                     </span>
-                                </li>
-                            </ul>
-                        </div>
+                                            </li>
+                                        </ul>
+                                    </div>
 
-                        <div ng-switch-when="org.apache.brooklyn.api.entity.EntitySpec" ng-init="adjunct = config[item.name][REPLACED_DSL_ENTITYSPEC]">
-                            <div class="spec-adjunct" ng-if="config[item.name][REPLACED_DSL_ENTITYSPEC]">
-                                <a ui-sref="main.graphical.edit.spec({entityId: model._id, specId: adjunct._id})"
-                                            class="open-entity-spec"
-                                            title="Open in spec editor"
-                                            ng-focus="specEditor.recordFocus(item)"></a>
-                                <ng-include src="'blueprint-composer/component/spec-editor/adjunct.html'"></ng-include>
-                            </div>
-                            <a ng-if="!config[item.name][REPLACED_DSL_ENTITYSPEC]" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'spec', configKey: item.name})" class="no-spec">
-                                (no spec set)
-                            </a>
-                        </div>
+                                    <div ng-switch-when="org.apache.brooklyn.api.entity.EntitySpec" ng-init="adjunct = config[item.name][REPLACED_DSL_ENTITYSPEC]">
+                                        <div class="spec-adjunct" ng-if="config[item.name][REPLACED_DSL_ENTITYSPEC]">
+                                            <a ui-sref="main.graphical.edit.spec({entityId: model._id, specId: adjunct._id})"
+                                               class="open-entity-spec"
+                                               title="Open in spec editor"
+                                               ng-focus="specEditor.recordFocus(item)"></a>
+                                            <ng-include src="'blueprint-composer/component/spec-editor/adjunct.html'"></ng-include>
+                                        </div>
+                                        <a ng-if="!config[item.name][REPLACED_DSL_ENTITYSPEC]" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'spec', configKey: item.name})" class="no-spec">
+                                            (no spec set)
+                                        </a>
+                                    </div>
 
-                        <div class="input-group" ng-switch-default>
+                                    <div class="input-group" ng-switch-default>
                             <span class="main-control span-for-rounded-edge">
                                 <textarea ng-model="config[item.name]" class="form-control rounded-edge" name="{{item.name}}" id="{{item.name}}" auto-grow
-                                      placeholder="{{defined(config[item.name]) ? null : item.defaultValue=='' || item.defaultValue==null ? '(empty)' : item.defaultValue}}"
-                                      ng-focus="specEditor.recordFocus(item)" on-enter="specEditor.advanceOutToFormGroupInPanel"></textarea>
+                                          placeholder="{{defined(config[item.name]) ? null : item.defaultValue=='' || item.defaultValue==null ? '(empty)' : item.defaultValue}}"
+                                          ng-focus="specEditor.recordFocus(item)" on-enter="specEditor.advanceOutToFormGroupInPanel"></textarea>
                             </span>
-                            <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name)">
+                                        <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name)">
                                 <a ui-sref="main.graphical.edit.dsl({entityId: model._id, for: item.name})" class="btn btn-default" title="Open in DSL editor"><i class="fa fa-bolt"></i></a>
                             </span>
+                                    </div>
+
+                                    <dsl-viewer dsl="model.config.get(item.name)" ng-switch-when="dsl-viewer"></dsl-viewer>
+
+                                </div>
+
+                                <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
+                            </div>
+
                         </div>
-
-                        <dsl-viewer dsl="model.config.get(item.name)" ng-switch-when="dsl-viewer"></dsl-viewer>
-                        
                     </div>
-                    
-                    <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
-                  </div>
+                </form>
+            </div>
+        </div>
 
+        <!-- ENTITY LOCATION -->
+        <ng-include ng-if="$root.selectedSection.type.id === 'LOCATION'" src="'blueprint-composer/component/spec-editor/section-locations.html'"></ng-include>
+        <script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-locations.html" defer-to-preexisting-id="true">
+            <div class="core-config-panel" ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.location.open">
+                <div>
+                    <div>Location</div>
+                    <span ng-if="(model.issues | filter:{group:'location'}).length> 0" class="badge" ng-class="getBadgeClass((model.issues | filter:{group:'location'}))">{{(model.issues | filter:{group:'location'}).length}}</span>
+                    <div></div>
+                </div>
+
+                <div class="spec-location">
+                    <div ng-repeat="issue in model.issues | filter:{group:'location'}" class="alert" ng-class="{'alert-warning': issue.level.id === 'warn', 'alert-danger': issue.level.id === 'error'}" role="alert">
+                        <span ng-bind-html="issue.message"></span>
+                    </div>
+                    <div class="spec-empty-state" ng-if="!model.hasLocation()">
+                        <h4>No location attached</h4>
+                        <p ng-if="!model.hasLocation() && model.hasInheritedLocation()">However, location <strong class="text-primary">{{model.getInheritedLocation()}}</strong> has been attached on an ancestor.</p>
+                    </div>
+                    <div ng-if="model.hasLocation()">
+                        <p ng-repeat="issue in state.issues | filter:{group:'location'}" class="alert alert-{{issue.severity}}">
+                            <em ng-bind-html="issue.message"></em>
+                        </p>
+                        <p>Will be deployed to: <strong>{{model.miscData.get('locationName')}}</strong></p>
+                        <a class="btn btn-default" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'location'})">Change location</a>
+                        <button class="btn btn-danger btn-link" ng-click="model.clearIssues({group: 'location'}).removeLocation()">Remove</button>
+                    </div>
                 </div>
             </div>
-        </form>
+        </script>
+
+        <!-- ENTITY POLICIES -->
+        <ng-include ng-if="$root.selectedSection.type.id === 'POLICY'" src="'blueprint-composer/component/spec-editor/section-policies.html'"></ng-include>
+        <script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-policies.html" defer-to-preexisting-id="true">
+            <div class="core-config-panel" ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.policy.open">
+                <div>
+                    <div>Policies</div>
+                    <span ng-if="getPoliciesIssues().length> 0" class="badge" ng-class="getBadgeClass(getPoliciesIssues())">{{getPoliciesIssues().length}}</span>
+                    <div>
+                        <i class="fa fa-search collapsible-action" title="Filter policies" ng-click="$event.stopPropagation(); $event.preventDefault();" ng-class="{'text-success': state.policy.search.length > 0}" uib-popover-template="'blueprint-composer/component/spec-editor/search-policy.html'"
+                           popover-placement="bottom-right" popover-trigger="'outsideClick'"></i>
+                    </div>
+                </div>
+
+                <div class="spec-policies">
+                    <div class="spec-empty-state" ng-if="!model.hasPolicies() || filteredPolicies.length === 0 ">
+                        <h4 ng-if="!model.hasPolicies()">No policies attached</h4>
+                        <h4 ng-if="model.hasPolicies() && filteredPolicies.length === 0">No policies matching the current search</h4>
+                        <p>
+                            <button class="btn btn-sm btn-default" ng-if="state.policy.search.length > 0" ng-click="state.policy.search = ''">Clear search</button>
+                        </p>
+                    </div>
+
+                    <div ng-repeat="adjunct in filteredPolicies = (model.getPoliciesAsArray() | specEditorType:state.policy.search) track by adjunct._id" class="spec-policy spec-adjunct">
+                        <a ui-sref="main.graphical.edit.policy({entityId: model._id, policyId: adjunct._id})"></a>
+                        <ng-include src="'blueprint-composer/component/spec-editor/adjunct.html'"></ng-include>
+                    </div>
+                </div>
+            </div>
+        </script>
+
+        <!-- ENTITY ENRICHERS -->
+        <ng-include ng-if="$root.selectedSection.type.id === 'ENRICHER'" src="'blueprint-composer/component/spec-editor/section-enrichers.html'"></ng-include>
+        <script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-enrichers.html" defer-to-preexisting-id="true">
+            <div class="core-config-panel" ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.enricher.open">
+                <div>
+                    <div>Enrichers</div>
+                    <span ng-if="getEnrichersIssues().length> 0" class="badge" ng-class="getBadgeClass(getEnrichersIssues())">{{getEnrichersIssues().length}}</span>
+                    <div>
+                        <i class="fa fa-search collapsible-action" title="Search enrichers" ng-click="$event.stopPropagation(); $event.preventDefault();" ng-class="{'text-success': state.enricher.search.length > 0}" uib-popover-template="'blueprint-composer/component/spec-editor/search-enricher.html'"
+                           popover-placement="bottom-right" popover-trigger="'outsideClick'"></i>
+                    </div>
+                </div>
+
+                <div class="spec-enrichers">
+                    <div class="spec-empty-state" ng-if="!model.hasEnrichers() || filteredEnrichers.length === 0">
+                        <h4 ng-if="!model.hasEnrichers()">No Enrichers attached</h4>
+                        <h4 ng-if="model.hasEnrichers() && filteredEnrichers.length === 0">No enrichers matching the current search</h4>
+                        <p>
+                            <button class="btn btn-sm btn-default" ng-if="state.enricher.search.length > 0" ng-click="state.enricher.search = ''">Clear search</button>
+                        </p>
+                    </div>
+
+                    <div ng-repeat="adjunct in filteredEnrichers = (model.getEnrichersAsArray() | specEditorType:state.enricher.search) track by adjunct._id" class="spec-enricher spec-adjunct">
+                        <a ui-sref="main.graphical.edit.enricher({entityId: model._id, enricherId: adjunct._id})"></a>
+                        <ng-include src="'blueprint-composer/component/spec-editor/adjunct.html'"></ng-include>
+                    </div>
+                </div>
+            </div>
+        </script>
+
+        <script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-others.html" defer-to-preexisting-id="true"></script>
     </div>
-</br-collapsible>
-
-<!-- ENTITY LOCATION -->
-<ng-include src="'blueprint-composer/component/spec-editor/section-locations.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-locations.html" defer-to-preexisting-id="true">
-  <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.location.open">
-    <heading>
-        Location
-        <span ng-if="(model.issues | filter:{group:'location'}).length> 0" class="badge" ng-class="getBadgeClass((model.issues | filter:{group:'location'}))">{{(model.issues | filter:{group:'location'}).length}}</span>
-    </heading>
-
-    <div class="spec-location">
-        <div ng-repeat="issue in model.issues | filter:{group:'location'}" class="alert" ng-class="{'alert-warning': issue.level.id === 'warn', 'alert-danger': issue.level.id === 'error'}" role="alert">
-            <span ng-bind-html="issue.message"></span>
-        </div>
-        <div class="spec-empty-state" ng-if="!model.hasLocation()">
-            <h4>No location attached</h4>
-            <p ng-if="!model.hasLocation() && model.hasInheritedLocation()">However, location <strong class="text-primary">{{model.getInheritedLocation()}}</strong> has been attached on an ancestor.</p>
-            <p><a ui-sref="main.graphical.edit.add({entityId: model._id, family: 'location'})" class="btn btn-sm btn-success"><i class="fa fa-plus"></i> Attach a location</a></p>
-        </div>
-        <div ng-if="model.hasLocation()">
-            <p ng-repeat="issue in state.issues | filter:{group:'location'}" class="alert alert-{{issue.severity}}">
-                <em ng-bind-html="issue.message"></em>
-            </p>
-            <p>Will be deployed to: <strong>{{model.miscData.get('locationName')}}</strong></p>
-            <a class="btn btn-default" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'location'})">Change location</a>
-            <button class="btn btn-danger btn-link" ng-click="model.clearIssues({group: 'location'}).removeLocation()">Remove</button>
-        </div>
-    </div>
-  </br-collapsible>
-</script>
-
-<!-- ENTITY POLICIES -->
-<ng-include src="'blueprint-composer/component/spec-editor/section-policies.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-policies.html" defer-to-preexisting-id="true">
-  <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.policy.open">
-    <heading>
-        Policies
-        <span ng-if="getPoliciesIssues().length> 0" class="badge" ng-class="getBadgeClass(getPoliciesIssues())">{{getPoliciesIssues().length}}</span>
-
-        <span class="pull-right" ng-show="$parent.stateWrapped.state">
-            <i class="fa fa-search collapsible-action" title="Filter policies" ng-click="$event.stopPropagation(); $event.preventDefault();" ng-class="{'text-success': state.policy.search.length > 0}" uib-popover-template="'blueprint-composer/component/spec-editor/search-policy.html'" popover-placement="bottom-right" popover-trigger="'outsideClick'"></i>
-            <a class="fa fa-plus collapsible-action" title="Add policy" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'policy'})" ng-click="$event.stopPropagation()" ></a>
-        </span>
-    </heading>
-
-    <div class="spec-policies">
-        <div class="spec-empty-state" ng-if="!model.hasPolicies() || filteredPolicies.length === 0 ">
-            <h4 ng-if="!model.hasPolicies()">No policies attached</h4>
-            <h4 ng-if="model.hasPolicies() && filteredPolicies.length === 0">No policies matching the current search</h4>
-            <p>
-                <button class="btn btn-sm btn-default" ng-if="state.policy.search.length > 0" ng-click="state.policy.search = ''">Clear search</button>
-                <a ui-sref="main.graphical.edit.add({entityId: model._id, family: 'policy'})" class="btn btn-sm btn-success">
-                    <i class="fa fa-plus"></i>
-                    <span ng-if="!model.hasPolicies()">Attach a policy</span>
-                    <span ng-if="model.hasPolicies() && filteredPolicies.length === 0">Attach another policy</span>
-                </a>
-            </p>
-        </div>
-
-        <div ng-repeat="adjunct in filteredPolicies = (model.getPoliciesAsArray() | specEditorType:state.policy.search) track by adjunct._id" class="spec-policy spec-adjunct">
-            <a ui-sref="main.graphical.edit.policy({entityId: model._id, policyId: adjunct._id})"></a>
-            <ng-include src="'blueprint-composer/component/spec-editor/adjunct.html'"></ng-include>
-        </div>
-    </div>
-  </br-collapsible>
-</script>
-
-<!-- ENTITY ENRICHERS -->
-<ng-include src="'blueprint-composer/component/spec-editor/section-enrichers.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-enrichers.html" defer-to-preexisting-id="true">
-  <br-collapsible ng-if="[FAMILIES.ENTITY, FAMILIES.SPEC].indexOf(model.family) > -1" state="state.enricher.open">
-    <heading>
-        Enrichers
-        <span ng-if="getEnrichersIssues().length> 0" class="badge" ng-class="getBadgeClass(getEnrichersIssues())">{{getEnrichersIssues().length}}</span>
-
-        <span class="pull-right" ng-show="$parent.stateWrapped.state">
-            <i class="fa fa-search collapsible-action" title="Search enrichers" ng-click="$event.stopPropagation(); $event.preventDefault();" ng-class="{'text-success': state.enricher.search.length > 0}" uib-popover-template="'blueprint-composer/component/spec-editor/search-enricher.html'" popover-placement="bottom-right" popover-trigger="'outsideClick'"></i>
-            <a class="fa fa-plus collapsible-action" title="Add enricher" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'enricher'})" ng-click="$event.stopPropagation()" ></a>
-        </span>
-    </heading>
-
-    <div class="spec-enrichers">
-        <div class="spec-empty-state" ng-if="!model.hasEnrichers() || filteredEnrichers.length === 0">
-            <h4 ng-if="!model.hasEnrichers()">No Enrichers attached</h4>
-            <h4 ng-if="model.hasEnrichers() && filteredEnrichers.length === 0">No enrichers matching the current search</h4>
-            <p>
-                <button class="btn btn-sm btn-default" ng-if="state.enricher.search.length > 0" ng-click="state.enricher.search = ''">Clear search</button>
-                <a ui-sref="main.graphical.edit.add({entityId: model._id, family: 'enricher'})" class="btn btn-sm btn-success">
-                    <i class="fa fa-plus"></i>
-                    <span ng-if="!model.hasEnrichers()">Attach an enricher</span>
-                    <span ng-if="model.hasEnrichers() && filteredEnrichers.length === 0">Attach another enricher</span>
-                </a>
-            </p>
-        </div>
-
-        <div ng-repeat="adjunct in filteredEnrichers = (model.getEnrichersAsArray() | specEditorType:state.enricher.search) track by adjunct._id" class="spec-enricher spec-adjunct">
-            <a ui-sref="main.graphical.edit.enricher({entityId: model._id, enricherId: adjunct._id})"></a>
-            <ng-include src="'blueprint-composer/component/spec-editor/adjunct.html'"></ng-include>
+    <div class="toolbar" ng-if="specEditor.needToolbar">
+        <div class="list-group">
+            <a href="" class="list-group-item ng-scope"
+               ng-repeat="section in specEditor.sections track by $index"
+               ng-class="{'active': $root.selectedSection === section}"
+               ng-click="$root.selectedSection = section">
+                <i class="fa fa-fw" ng-class="section.icon"></i>
+            </a>
         </div>
     </div>
-  </br-collapsible>
-</script>
-
-<ng-include src="'blueprint-composer/component/spec-editor/section-others.html'"></ng-include>
-<script type="text/ng-template" id="blueprint-composer/component/spec-editor/section-others.html" defer-to-preexisting-id="true">
-</script>
-
+</div>
 
 <!-- CONFIG INFO TEMPLATE :: START -->
 <script type="text/ng-template" id="blueprint-composer/component/spec-editor/config-info.html" defer-to-preexisting-id="true">
     <div class="config-item-quick-info">
         <div class="quick-info-metadata">
             <p><i class="mini-icon fa fa-fw fa-cog"></i> <samp class="type-symbolic-name">{{item.name}}</samp>
-            <span class="config-type label-color column-for-type oneline label label-success">{{item.type}}</span></p>
+                <span class="config-type label-color column-for-type oneline label label-success">{{item.type}}</span></p>
         </div>
         <p class="quick-info-description" ng-if="item.description" ng-bind-html="specEditor.descriptionHtml(item.description)"></p>
         <div class="quick-info-metadata config-default" ng-if="item.defaultValue"></i>Default value: <samp>{{item.defaultValue}}</samp></div>
         <div class="quick-info-metadata config-required" ng-if="item.constraints.required"><i>This field is required.</div>
     </div>
-        
+
 </script>
 <!-- CONFIG INFO TEMPLATE :: START-->
 
 <!-- SEARCH POLICY TEMPLATE :: START -->
 <script type="text/ng-template" id="blueprint-composer/component/spec-editor/search-policy.html" defer-to-preexisting-id="true">
     <div ng-click="$event.stopPropagation(); $event.preventDefault();">
-        <input ng-model="state.policy.search" type="text" class="form-control" placeholder="Search for a policy" auto-focus blur-on-enter />
+        <input ng-model="state.policy.search" type="text" class="form-control" placeholder="Search for a policy" auto-focus blur-on-enter/>
     </div>
 </script>
 <!--SEARCH POLICY TEMPLATE :: START-->
@@ -473,7 +486,7 @@
 <!-- SEARCH ENRICHER TEMPLATE :: START -->
 <script type="text/ng-template" id="blueprint-composer/component/spec-editor/search-enricher.html" defer-to-preexisting-id="true">
     <div ng-click="$event.stopPropagation(); $event.preventDefault();">
-        <input ng-model="state.enricher.search" type="text" class="form-control" placeholder="Search for an enricher" auto-focus blur-on-enter />
+        <input ng-model="state.enricher.search" type="text" class="form-control" placeholder="Search for an enricher" auto-focus blur-on-enter/>
     </div>
 </script>
 <!--SEARCH ENRICHER TEMPLATE :: START-->
@@ -497,12 +510,12 @@
 <script type="text/ng-template" id="blueprint-composer/component/spec-editor/adjunct.html" defer-to-preexisting-id="true">
     <div class="media" ng-class="{'has-issues': adjunct.hasIssues()}">
         <div class="media-left media-middle">
-            <img ng-src="{{adjunct.icon}}" alt="{{adjunct | entityName}} logo" class="media-object" />
+            <img ng-src="{{adjunct.icon}}" alt="{{adjunct | entityName}} logo" class="media-object"/>
         </div>
         <div class="media-body">
             <div>
                 {{adjunct.miscData.get('typeName')}}
-                <span ng-if="adjunct.issues.length > 0" > • <small class="text-danger">
+                <span ng-if="adjunct.issues.length > 0"> • <small class="text-danger">
                     <em>
                       <i class="fa fa-ban"></i>
                         <ng-pluralize count="adjunct.issues.length" when="{
@@ -520,3 +533,4 @@
     </div>
 </script>
 <!--ADJUNCT TEMPLATE :: END-->
+

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -30,7 +30,6 @@ export function D3Blueprint(container) {
     let _relationGroup = _parentGroup.append('g').attr('class', 'relation-group');
     let _specNodeGroup = _parentGroup.append('g').attr('class', 'spec-node-group');
     let _dropZoneGroup = _parentGroup.append('g').attr('class', 'dropzone-group');
-    let _ghostNodeGroup = _parentGroup.append('g').attr('class', 'ghost-node-group');
     let _nodeGroup = _parentGroup.append('g').attr('class', 'node-group');
     let _cloneGroup = _parentGroup.append('g').attr('class', 'clone-group');
 
@@ -167,7 +166,6 @@ export function D3Blueprint(container) {
     };
     let _d3DataHolder = {
         nodes: [],
-        ghostNodes: [],
         orphans: [],
         links: [],
         relationships: [],
@@ -261,25 +259,6 @@ export function D3Blueprint(container) {
             _dropZoneGroup.selectAll('.dropzone-prev').classed('hidden', false);
             _dropZoneGroup.selectAll('.dropzone-next').classed('hidden', false);
         }
-    }
-
-    /**
-     * Mouse Enter Event Handler
-     *
-     * @param {object} node The graph node the mouse is over
-     */
-    function onGhostOver(node) {
-        d3.select(`#ghost-node-${node.data._id} g.buttons`).classed('active', true);
-        // show whole group not just buttons
-    }
-
-    /**
-     * Mouse Leave Event Handler
-     *
-     * @param {object} node The graph node the mouse just left
-     */
-    function onGhostLeave(node) {
-        d3.select(`#ghost-node-${node.data._id} g.buttons`).classed('active', false);
     }
 
     /**
@@ -451,8 +430,6 @@ export function D3Blueprint(container) {
             if (id) {
                 _dropZoneGroup.select(`#${id}`).classed('active', true)
             }
-        } else {
-            onGhostOver(node);
         }
     }
 
@@ -472,8 +449,6 @@ export function D3Blueprint(container) {
             if (id) {
                 _dropZoneGroup.select(`#${id}`).classed('active', false)
             }
-        } else {
-            onGhostLeave(node);
         }
     }
 
@@ -541,7 +516,6 @@ export function D3Blueprint(container) {
         drawRelationships();
         drawNodeGroup();
         drawSpecNodeGroup();
-        drawGhostNode();
         drawDropZoneGroup();
         return this;
     }
@@ -577,8 +551,6 @@ export function D3Blueprint(container) {
         let entity = nodeGroup.append('g')
             .attr('class', 'node-entity entity')
             .on('click', onEntityClick)
-            .on('mouseenter', onGhostOver)
-            .on('mouseleave', onGhostLeave)
             .call(d3.drag()
                 .on('start', onDragStart)
                 .on('drag', onDrag)
@@ -729,40 +701,6 @@ export function D3Blueprint(container) {
             .duration(_configHolder.transition)
             .attr('opacity', 0)
             .remove();
-    }
-
-    function drawGhostNode() {
-        let ghostNodeData = _ghostNodeGroup.selectAll('g.ghost-node')
-            .data(_d3DataHolder.nodes, (d)=>(`ghost-node-${d.data._id}`));
-        let ghostNode = ghostNodeData
-            .enter()
-            .append('g')
-            .attr('id', (d)=>(`ghost-node-${d.data._id}`))
-            .attr('class', 'ghost-node')
-            .attr('transform', (d)=>(`translate(${d.x}, ${d.y})`))
-            .on('mouseenter', onGhostOver)
-            .on('mouseleave', onGhostLeave);
-        ghostNodeData
-            .transition()
-            .duration(_configHolder.transition)
-            .attr('transform', (d)=>(`translate(${d.x}, ${d.y})`));
-        ghostNodeData.exit().remove();
-
-        ghostNode.append('rect')
-            .attr('class', 'ghost')
-            .attr('width', (d)=>(isRootNode(d) ? _configHolder.nodes.root.rect.width : _configHolder.nodes.child.circle.r * 2))
-            .attr('height', (d)=>((isRootNode(d) ? _configHolder.nodes.root.rect.height : _configHolder.nodes.child.circle.r * 2) + 80))
-            .attr('x', (d)=>(isRootNode(d) ? _configHolder.nodes.root.rect.x : -_configHolder.nodes.child.circle.r))
-            .attr('y', (d)=>(isRootNode(d) ? _configHolder.nodes.root.rect.y : -_configHolder.nodes.child.circle.r));
-
-        let buttonsGroup = ghostNode.append('g')
-            .attr('class', 'buttons');
-        appendElements(buttonsGroup, _configHolder.nodes.buttongroup);
-
-        let buttonAdd = buttonsGroup.append('g')
-            .attr('class', 'button button-add')
-            .on('click', onAddChildClick);
-        appendElements(buttonAdd, _configHolder.nodes.buttonAdd);
     }
 
     function drawDropZoneGroup() {

--- a/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/edit/add/add.html
@@ -23,18 +23,6 @@
 </section>
 
  <div class="add-panel-main">
-    <div class="toolbar">
-        <div class="list-group">
-            <a href class="list-group-item"
-               ng-repeat="section in vm.sections track by $index"
-               ng-class="{'active': vm.selectedSection === section}"
-               ng-if="familiesToShow.indexOf(section.type) >= 0"
-               ng-click="vm.selectedSection = section">
-                <i class="fa fa-fw" ng-class="section.icon"></i>
-            </a>
-        </div>
-    </div>
-
   <div class="pane pane-palette" ng-if="vm.selectedSection">
     <div ng-repeat="section in vm.sections track by $index"
          class="palette-full-height-wrapper"
@@ -42,7 +30,6 @@
         <div class="container-fluid palette-title">
             <h3>
                 {{section.title}}
-                <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
             </h3>
         </div>
         <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.onTypeSelected(item)" on-select-text="vm.getOnSelectText(item)" icon-selects="true" class="palette-full-height-wrapper"></catalog-selector>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -20,7 +20,7 @@
 <div class="palette-and-or-toolbar">
 
   <div class="layout">
-    <div class="toolbar">
+    <div class="toolbar toolbar-left">
         <div class="list-group">
             <a href class="list-group-item"
                ng-repeat="section in vm.sections track by $index"
@@ -48,7 +48,7 @@
     </div>
   </div>
 
-  <div class="pane pane-configuration">
+  <div ng-class="['pane', 'pane-configuration', {'config-panel-open': $root.selectedSection && vm.$state.current.name != 'main.graphical'}]">
     <ui-view></ui-view>
   </div>
 

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.js
@@ -38,6 +38,9 @@ export const graphicalState = {
 function graphicalController($scope, $state, $filter, blueprintService, paletteService) {
     this.EntityFamily = EntityFamily;
 
+    $scope.$root.selectedSection = paletteService.getSections().entities;
+    this.$state = $state;
+
     this.sections = paletteService.getSections();
     this.selectedSection = Object.values(this.sections).find(section => section.type === EntityFamily.ENTITY);
     $scope.paletteState = {};  // share state among all sections

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -29,19 +29,9 @@
     position: relative;
     height: calc(~"100vh - 105px");
     background-color: #fff;
-    overflow-y: scroll;
+    overflow-y: auto;
     z-index: 40;
-    box-shadow: 0 0 10px 2px @navbar-default-border;
-
-    &:after {
-      position: absolute;
-      content: '';
-      width: 1px;
-      top: 0;
-      bottom: 0;
-      right: 0;
-      background-color: @navbar-default-border;
-    }
+    flex-shrink: 0;
 
     .list-group-item {
       @active-border-width: 4px;
@@ -62,6 +52,10 @@
         padding-bottom: 10px;
       }
     }
+  }
+
+  .toolbar-left {
+    box-shadow: -5px 0 10px 5px @navbar-default-border;
   }
   
   #palette-controls-button {
@@ -132,12 +126,13 @@
   bottom: 0;
   background-color: #fff;
   z-index: 40;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   &.pane-palette {
-    left: 49px;
-    width: 440px;
+    left: 48px;
+    width: 23%;
     box-shadow: 5px 0 10px -2px @navbar-default-border;
+    border-left: 1px solid @navbar-default-border;
 
     .palette-title {
         margin-left: 0;
@@ -166,9 +161,12 @@
     right: 0;
     box-shadow: 5px 0 10px 5px @navbar-default-border;
 
+    &.config-panel-open {
+        width: 23%;
+    }
+
     & > ui-view > ui-view {
       display: block;
-      width: 489px;
     }
 
     .pane-palette .container-fluid {
@@ -233,8 +231,6 @@
     .panel-group {
       margin-bottom: 0;
       .panel {
-        border-bottom: 1px solid @gray-lighter;
-        margin: 0 12px;
         border-radius: 0;
         box-shadow: none;
         .panel-heading {
@@ -271,5 +267,13 @@
         }
       }
     }
+  }
+
+  .br-icon-close-bar {
+    stroke: @gray-light ;
+  }
+
+  svg:hover .br-icon-close-bar {
+    stroke: black;
   }
 }


### PR DESCRIPTION
As proposed in the mailing list we implemented some modifications to the three panels view.
We separated the functionalities : We add every kind of items with the left panel, and all the configuration is done with the right panel.
We also add a way to reduce/close the right panel. It will stay closed until voluntarily reopened.
You can see the result in the following video : https://webmshare.com/ayKMQ
