### PR TITLE
require login to webconsole for webapps

### DIFF
--- a/modularity-server/features/pom.xml
+++ b/modularity-server/features/pom.xml
@@ -63,46 +63,11 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
+                <version>${karaf.plugin.version}</version>
+                <extensions>true</extensions>
                 <configuration>
                     <startLevel>100</startLevel>
-                    <aggregateFeatures>true</aggregateFeatures>		
-                    <resolver>(obr)</resolver>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>verify-brooklyn-ui-modularity-feature</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <distribution>org.apache.karaf.features:framework</distribution>
-                            <framework><!--REQUIRED FEATURES-->
-                                <feature>framework</feature>
-                                <feature>aries-blueprint</feature>
-                                <feature>config</feature>
-                                <feature>feature</feature>
-                                <feature>service</feature>
-                                <feature>ssh</feature>
-                                <feature>system</feature>
-                                <feature>wrap</feature>
-                                <feature>brooklyn-osgi-launcher</feature>
-                                <feature>brooklyn-rest-resources</feature>
-                            </framework>
-                            <features><!--SELECTED FEATURES TO VERIFY-->
-                                <feature>brooklyn-ui-modularity</feature>
-                                <feature>brooklyn-ui-modularity-prereqs</feature>
-                                <feature>brooklyn-ui-proxy</feature>
-                            </features>
-                            <descriptors>
-                                <descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.brooklyn/brooklyn-features/${brooklyn.version}/xml/features</descriptor>
-                                <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
-                            </descriptors>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/ui-modules/app-inspector/pom.xml
+++ b/ui-modules/app-inspector/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/app-inspector/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/app-inspector/src/main/webapp/WEB-INF/web.xml
@@ -60,5 +60,22 @@
     </filter-mapping>
     <!--FILTERS :: END-->
 
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
 
 </web-app>

--- a/ui-modules/app-inspector/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/app-inspector/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
 
 </web-app>

--- a/ui-modules/blueprint-composer/pom.xml
+++ b/ui-modules/blueprint-composer/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/blueprint-composer/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/blueprint-composer/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-    
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
 
 </web-app>

--- a/ui-modules/blueprint-composer/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/blueprint-composer/src/main/webapp/WEB-INF/web.xml
@@ -60,5 +60,22 @@
     </filter-mapping>
     <!--FILTERS :: END-->
 
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+    
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
 
 </web-app>

--- a/ui-modules/blueprint-importer/pom.xml
+++ b/ui-modules/blueprint-importer/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/blueprint-importer/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/blueprint-importer/src/main/webapp/WEB-INF/web.xml
@@ -60,5 +60,22 @@
     </filter-mapping>
     <!--FILTERS :: END-->
 
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
 
 </web-app>

--- a/ui-modules/blueprint-importer/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/blueprint-importer/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
 
 </web-app>

--- a/ui-modules/catalog/pom.xml
+++ b/ui-modules/catalog/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/catalog/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/catalog/src/main/webapp/WEB-INF/web.xml
@@ -60,5 +60,22 @@
     </filter-mapping>
     <!--FILTERS :: END-->
 
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
 
 </web-app>

--- a/ui-modules/catalog/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/catalog/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
 
 </web-app>

--- a/ui-modules/features/pom.xml
+++ b/ui-modules/features/pom.xml
@@ -71,46 +71,11 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
+                <version>${karaf.plugin.version}</version>
+                <extensions>true</extensions>
                 <configuration>
                     <startLevel>100</startLevel>
-                    <aggregateFeatures>true</aggregateFeatures>
-                    <resolver>(obr)</resolver>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>verify-brooklyn-ui-modules-feature</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <distribution>org.apache.karaf.features:framework</distribution>
-                            <framework><!--REQUIRED FEATURES-->
-                                <feature>framework</feature>
-                                <feature>aries-blueprint</feature>
-                                <feature>config</feature>
-                                <feature>feature</feature>
-                                <feature>service</feature>
-                                <feature>ssh</feature>
-                                <feature>system</feature>
-                                <feature>wrap</feature>
-                                <feature>brooklyn-osgi-launcher</feature>
-                                <feature>brooklyn-rest-resources</feature>
-                                <feature>brooklyn-ui-modularity</feature>
-                            </framework>
-                            <features><!--FEATURES TO VERIFY-->
-                                <feature>brooklyn-ui-modules</feature>
-                            </features>
-                            <descriptors>
-                                <descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.brooklyn/brooklyn-features/${brooklyn.version}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.brooklyn.ui.modularity/brooklyn-ui-modularity-features/${brooklyn.version}/xml/features</descriptor>
-                                <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
-                            </descriptors>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/ui-modules/groovy-console/pom.xml
+++ b/ui-modules/groovy-console/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/groovy-console/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/groovy-console/src/main/webapp/WEB-INF/web.xml
@@ -60,5 +60,22 @@
     </filter-mapping>
     <!--FILTERS :: END-->
 
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
 
 </web-app>

--- a/ui-modules/groovy-console/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/groovy-console/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
 
 </web-app>

--- a/ui-modules/home/pom.xml
+++ b/ui-modules/home/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/home/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/home/src/main/webapp/WEB-INF/web.xml
@@ -59,4 +59,23 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
+    
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+    
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
+  
 </web-app>

--- a/ui-modules/home/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/home/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-    
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-    
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
   
 </web-app>

--- a/ui-modules/location-manager/pom.xml
+++ b/ui-modules/location-manager/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/location-manager/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/location-manager/src/main/webapp/WEB-INF/web.xml
@@ -60,5 +60,22 @@
     </filter-mapping>
     <!--FILTERS :: END-->
 
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
 
 </web-app>

--- a/ui-modules/location-manager/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/location-manager/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
 
 </web-app>

--- a/ui-modules/logout/pom.xml
+++ b/ui-modules/logout/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/logout/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/logout/src/main/webapp/WEB-INF/web.xml
@@ -27,4 +27,18 @@
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
+
 </web-app>

--- a/ui-modules/logout/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/logout/src/main/webapp/WEB-INF/web.xml
@@ -28,17 +28,6 @@
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
 
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
+    <!--no security for this module so we can confirm that the user has logged out-->
 
 </web-app>

--- a/ui-modules/rest-api-docs/pom.xml
+++ b/ui-modules/rest-api-docs/pom.xml
@@ -112,6 +112,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             org.apache.brooklyn.ui.modularity.module.api,
+                            org.apache.brooklyn.rest.filter,
                             org.eclipse.jetty.servlets,
                             *
                         </Import-Package>

--- a/ui-modules/rest-api-docs/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/rest-api-docs/src/main/webapp/WEB-INF/web.xml
@@ -60,5 +60,22 @@
     </filter-mapping>
     <!--FILTERS :: END-->
 
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>webconsole</realm-name>
+    </login-config>
+
+    <security-constraint>
+      <web-resource-collection>
+        <web-resource-name>webconsole-static-assets</web-resource-name>
+        <url-pattern>/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+        <role-name>**</role-name>
+      </auth-constraint>
+    </security-constraint>
+    <security-role>
+      <role-name>**</role-name>
+    </security-role>
 
 </web-app>

--- a/ui-modules/rest-api-docs/src/main/webapp/WEB-INF/web.xml
+++ b/ui-modules/rest-api-docs/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,10 @@
         </init-param>
     </filter>
     <filter>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <filter-class>org.apache.brooklyn.rest.filter.BrooklynSecurityProviderFilterJavax</filter-class>
+    </filter>
+    <filter>
         <filter-name>GzipFilter</filter-name>
         <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
         <init-param>
@@ -55,27 +59,13 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter-mapping>
+        <filter-name>brooklyn-security-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
         <filter-name>GzipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!--FILTERS :: END-->
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>webconsole</realm-name>
-    </login-config>
-
-    <security-constraint>
-      <web-resource-collection>
-        <web-resource-name>webconsole-static-assets</web-resource-name>
-        <url-pattern>/*</url-pattern>
-      </web-resource-collection>
-      <auth-constraint>
-        <role-name>**</role-name>
-      </auth-constraint>
-    </security-constraint>
-    <security-role>
-      <role-name>**</role-name>
-    </security-role>
 
 </web-app>


### PR DESCRIPTION
the REST API has always been secured but we now secure these static assets also;
this gives a better experience on login, and it will be even more important when
we introduce oauth-based logins where the redirect page (served by the LoginModule
defined in the REST API module, connected to the LoginService defined in the jetty bundle,
both in brooklyn-server) should be served in response to the request for index.html,
not just on the REST calls