### PR TITLE
tables should run with their own scope

### DIFF
--- a/ui-modules/utils/table/index.js
+++ b/ui-modules/utils/table/index.js
@@ -103,6 +103,7 @@ export function brTableDirective($log) {
         link: link,
         controller: ['$templateCache', 'brUtilsGeneral', controller],
         controllerAs: 'ctrl',
+        scope: true,
         templateUrl: function(element, attrs) {
             return attrs.templateUrl || TEMPLATE_CONTAINER_URL;
         }


### PR DESCRIPTION
without this if you put _two_ tables in the same parent controller view they collide on their data and have their own data