### PR TITLE
Fix the inline edit configuration for the policies in app inspector

### DIFF
--- a/ui-modules/app-inspector/app/components/entity-policy/entity-policy.less
+++ b/ui-modules/app-inspector/app/components/entity-policy/entity-policy.less
@@ -103,50 +103,51 @@ entity-policy {
   padding-top: 20px;
 }
 
-
 /* Editable text */
-
-
 .table-editable {
-  td.editable-click {
-    color: black;
-    &:hover {
-      border: none;
-    }
-  }
-  td.editable:not(.edit-disabled) {
-    cursor: pointer;
-    color: black;
-
-    &:hover {
-      border: none;
-      background: fade(@primary-500, 10%);
-      &:before {
-        opacity: 1.0;
-      }
-    }
-  }
-  td.editable:not(.edit-disabled):before {
-    font-family: "myriad-pro-1", Helvetica, Arial, sans-serif, FontAwesome;
-    content: '\f040 Edit';
-    float: right;
-    opacity: 0.2;
-    color: @primary-500;
+  .editable {
+    color: #000000;
+    border: none;
   }
 
-  .editable-wrap {
-    width: 100%;
-    .editable-controls {
+  .editable-column {
+    padding: 0;
+
+    .editable:not(.edit-disabled):after {
+      font-family: "myriad-pro-1", Helvetica, Arial, sans-serif, FontAwesome;
+      content: '\f040 Edit';
+      opacity: 0.2;
+      color: @primary-500;
+    }
+    .editable {
       display: flex;
-      flex-direction: row;
+      justify-content: space-between;
+      width: 100%;
+      padding: 8px;
 
-      input {
-        flex-grow: 2;
+      &:hover {
+        border: none;
+        background: fade(@primary-500, 10%);
+        &:after {
+          opacity: 1.0;
+        }
       }
+    }
 
-      .editable-buttons {
-        flex-grow: 0;
-        flex-shrink: 0;
+    .editable-wrap {
+      width: 100%;
+      .editable-controls {
+        display: flex;
+        flex-direction: row;
+
+        input {
+          flex-grow: 2;
+        }
+
+        .editable-buttons {
+          flex-grow: 0;
+          flex-shrink: 0;
+        }
       }
     }
   }

--- a/ui-modules/app-inspector/app/components/entity-policy/entity-policy.template.html
+++ b/ui-modules/app-inspector/app/components/entity-policy/entity-policy.template.html
@@ -37,18 +37,20 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="item in info | orderBy:'name':reverse | filter:{name: searchCriteria} track by item.name" ng-switch="item.type">
+                <tr ng-repeat="item in info | orderBy:'name':reverse | filter:{name: searchCriteria} track by item.name">
                     <td>
                         {{item.name}}
                     </td>
-                    <td ng-switch-when="java.lang.Number" editable-number="item.value" edit-disabled="!item.reconfigurable" onbeforesave="updateAdjunctConfig(item, $data)" buttons="right" e-disabled-submit-on-enter>
-                        {{item.value}}
-                    </td>
-                    <td ng-switch-when="java.lang.Integer" ng-class="{'edit-disabled': !item.reconfigurable}" editable-number="item.value" edit-disabled="!item.reconfigurable" onbeforesave="updateAdjunctConfig(item, $data)" buttons="right" e-disabled-submit-on-enter>
-                        {{item.value}}
-                    </td>
-                    <td ng-switch-default ng-class="{'edit-disabled': !item.reconfigurable}" editable-text="item.value" edit-disabled="!item.reconfigurable" onbeforesave="updateAdjunctConfig(item, $data)" buttons="right" e-disabled-submit-on-enter>
-                        {{item.value}}
+                    <td ng-switch="item.type" ng-class="{'editable-column': item.reconfigurable}">
+                        <div ng-switch-when="java.lang.Number" editable-number="item.value" edit-disabled="!item.reconfigurable" onbeforesave="updateAdjunctConfig(item, $data)" buttons="right" e-disabled-submit-on-enter>
+                            <span>{{item.value}}</span>
+                        </div>
+                        <div ng-switch-when="java.lang.Integer" ng-class="{'edit-disabled': !item.reconfigurable}" editable-number="item.value" edit-disabled="!item.reconfigurable" onbeforesave="updateAdjunctConfig(item, $data)" buttons="right" e-disabled-submit-on-enter>
+                            <span>{{item.value}}</span>
+                        </div>
+                        <div ng-switch-default ng-class="{'edit-disabled': !item.reconfigurable}" editable-text="item.value" edit-disabled="!item.reconfigurable" onbeforesave="updateAdjunctConfig(item, $data)" buttons="right" e-disabled-submit-on-enter>
+                            <span>{{item.value}}</span>
+                        </div>
                     </td>
                 </tr>
                 <tr ng-if="item.length == 0 ">


### PR DESCRIPTION
This was broken in Brooklyn previously: a white empty box was displayed instead of the form to edit the value.

This changes makes it cleaner and working as expected

![fix-policy-config](https://user-images.githubusercontent.com/2082759/52129948-d37d4a00-2630-11e9-9b83-b823fd15e1f0.gif)
