### PR TITLE
handle errors in custom widgets better

### DIFF
--- a/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
+++ b/ui-modules/blueprint-composer/app/components/custom-config-widget/suggestion-dropdown.js
@@ -46,21 +46,28 @@ export function suggestionDropdownDirective($rootScope) {
     };
 
     function link(scope, element, attrs, specEditor) {
-        scope.specEditor = specEditor;
-        scope.defined = specEditor.defined;
-        scope.getSuggestions = () => {
-            var result = [];
-            if (scope.params['suggestion-values']) {
-                scope.params['suggestion-values'].forEach( (v) => {
-                    if (v["value"]) {
-                        result.push(v);
-                    } else {
-                        result.push({value: v});
-                    }
-                });
-                return result;
+        try {
+            scope.specEditor = specEditor;
+            scope.defined = specEditor.defined;
+            scope.getSuggestions = () => {
+                var result = [];
+                if (scope.params['suggestion-values']) {
+                    scope.params['suggestion-values'].forEach( (v) => {
+                        if (v["value"]) {
+                            result.push(v);
+                        } else {
+                            result.push({value: v});
+                        }
+                    });
+                    return result;
+                }
+            };
+        } catch (e) {
+            if ($scope.params) {
+                $scope.params.error = e;
             }
-        };
+            throw e;
+        }
     }
 }
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -127,7 +127,7 @@
 
         <form name="formSpecConfig" novalidate class="lightweight">
             <div ng-repeat="item in (filteredItems = (model.miscData.get('config') | specEditorConfig:state.config.filter.values:model | filter:{name:state.config.search} | orderBy:+priority)) track by item.name ">
-                <div class="form-group" ng-class="{'has-error': (model.issues | filter:{ref: item.name}:true).length > 0, 'used': config[item.name] !== undefined}" 
+                <div class="form-group" ng-class="{'has-error': ((model.issues | filter:{ref: item.name}:true).length > 0) || (specEditor.customConfigWidgetError(item)), 'used': config[item.name] !== undefined}" 
                         ng-switch="getConfigWidgetMode(item)" 
                         tabindex="1"
                         auto-focus="state.config.focus === item.name"
@@ -332,6 +332,10 @@
                     </div>
                     
                     <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
+                    <small ng-if="specEditor.customConfigWidgetError(item)" class="help-block issue">
+                            Custom widget unavailable:
+                            {{ specEditor.customConfigWidgetError(item) }}
+                    </small>
                   </div>
 
                 </div>


### PR DESCRIPTION
now if *.error is set, the widget silently falls back to the default.
if a user clicks to show the custom widget, the error message is shown.
subsequent custom widget toggles hide or show the error.

this lets people writing custom widgets handle errors gracefully