### PR TITLE
Fix errors around locations in composer

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -614,7 +614,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         return entity;
     }
 
-    function populateLocationFromApiSuccess(entity, data) {
+    function populateLocationFromApiCommon(entity, data) {
         entity.clearIssues({group: 'location'});
         entity.location = data.yamlHere || data.symbolicName;
         
@@ -630,9 +630,13 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         entity.miscData.set('locationIcon', data==null ? null : data.iconUrl || iconGenerator(data.yamlHere ? JSON.stringify(data.yamlHere) : data.symbolicName));
         return entity;
     }
+    
+    function populateLocationFromApiSuccess(entity, data) {
+        populateLocationFromApiCommon(entity, data);
+    }
 
     function populateLocationFromApiError(entity) {
-        populateLocationFromApiSuccess(entity, { yamlHere: entity.location });
+        populateLocationFromApiCommon(entity, { yamlHere: entity.location });
         entity.addIssue(Issue.builder().level(ISSUE_LEVEL.WARN).group('location').message($sce.trustAsHtml(`Location <samp>${!(entity.location instanceof String) ? JSON.stringify(entity.location) : entity.location}</samp> does not exist in your local catalog. Deployment might fail.`)).build());
         entity.miscData.set('locationIcon', typeNotFoundIcon);
         return entity;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -255,7 +255,6 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         scope.nonempty = (o) => o && Object.keys(o).length;
         scope.defined = specEditor.defined = (o) => (typeof o !== 'undefined');
         specEditor.isInstance = (x, type) => (typeof x === type);
-        specEditor.json = x => JSON.stringify(x, null, 2);
                 
         specEditor.advanceOutToFormGroupInPanel = (element, event) => {
             focusIfPossible(event, findAncestor(element, "form-group", "panel-body")) || element[0].blur();

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -254,6 +254,9 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         }
         scope.nonempty = (o) => o && Object.keys(o).length;
         scope.defined = specEditor.defined = (o) => (typeof o !== 'undefined');
+        specEditor.isInstance = (x, type) => (typeof x === type);
+        specEditor.json = x => JSON.stringify(x, null, 2);
+                
         specEditor.advanceOutToFormGroupInPanel = (element, event) => {
             focusIfPossible(event, findAncestor(element, "form-group", "panel-body")) || element[0].blur();
         };

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -22,9 +22,6 @@
 @hide-info-button-when-not-hovered: false;
 @hide-unset-undefault-values: true;
 
-@label-gray: darken(@gray-light, 10%);
-@gray-lightest: #f8f8f9;
-
 spec-editor {
   display: block;
   margin-top: 15px;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -362,7 +362,12 @@
             <p ng-repeat="issue in state.issues | filter:{group:'location'}" class="alert alert-{{issue.severity}}">
                 <em ng-bind-html="issue.message"></em>
             </p>
-            <p>Will be deployed to: <strong>{{model.miscData.get('locationName')}}</strong></p>
+            <p>
+                Targeted at: 
+                <strong ng-if="specEditor.isInstance(model.location, 'string')">{{ model.miscData.get('locationName') }}</strong>
+                <pre ng-if="!specEditor.isInstance(model.location, 'string')">{{ specEditor.json(model.location) }}</pre>
+            </p>
+            <br/>
             <a class="btn btn-default" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'location'})">Change location</a>
             <button class="btn btn-danger btn-link" ng-click="model.clearIssues({group: 'location'}).removeLocation()">Remove</button>
         </div>

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -365,7 +365,7 @@
             <p>
                 Targeted at: 
                 <strong ng-if="specEditor.isInstance(model.location, 'string')">{{ model.miscData.get('locationName') }}</strong>
-                <pre ng-if="!specEditor.isInstance(model.location, 'string')">{{ specEditor.json(model.location) }}</pre>
+                <pre ng-if="!specEditor.isInstance(model.location, 'string')">{{ model.location | json }}</pre>
             </p>
             <br/>
             <a class="btn btn-default" ui-sref="main.graphical.edit.add({entityId: model._id, family: 'location'})">Change location</a>

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -617,11 +617,13 @@ export function D3Blueprint(container) {
             .duration(_configHolder.transition)
             .attr('opacity', (d)=>(d.data.hasLocation() ? 1 : 0));
         appendElements(location, _configHolder.nodes.location);
+        
         nodeData.select('g.node-location image')
             .transition()
             .duration(_configHolder.transition)
-            .attr('opacity', (d)=>(d.data.miscData.get('locationIcon') ? 1 : 0))
-            .attr('xlink:href', (d)=>(d.data.miscData.get('locationIcon')));
+            .attr('opacity', (d)=>(d.data.miscData.get('locationIcon') ? 1 : 0));
+        nodeData.select('g.node-location image')
+            .attr('xlink:href', (d)=>d.data.miscData.get('locationIcon'));
 
         // Draw important adjuncts (i.e policies/enrichers)
         // -----------------------------------------------------

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -272,6 +272,7 @@ export class Entity {
      */
     set location(location) {
         LOCATIONS.set(this, location);
+        this.miscData.delete('locationRemoved');
         this.touch();
     }
 
@@ -281,6 +282,13 @@ export class Entity {
      */
     removeLocation() {
         LOCATIONS.delete(this);
+        this.miscData.delete('locationName');
+        this.miscData.delete('locationIcon');
+        
+        // this field provides a way for consumers to detect if the location was explicitly removed;
+        // this can be useful to prevent default locations from being applied
+        this.miscData.set('locationRemoved', true);
+        
         this.touch();
     }
 

--- a/ui-modules/blueprint-composer/app/index.less
+++ b/ui-modules/blueprint-composer/app/index.less
@@ -36,9 +36,6 @@
 @import "components/catalog-saver/catalog-saver.less";
 @import "components/dsl-editor/dsl-editor";
 
-@gray-lighter: #E1E5E7;
-@gray-light: #818899;
-
 .make-icon(@size) {
   width: auto;
   height: auto;

--- a/ui-modules/utils/br-core/style/buttons.less
+++ b/ui-modules/utils/br-core/style/buttons.less
@@ -23,6 +23,9 @@
 .btn-accent {
     .button-variant(@btn-accent-color; @btn-accent-bg; @btn-accent-border);
 }
+.btn-light {
+  .button-variant(@gray-dark; @gray-lightest; @gray-lightest);
+}
 
 .btn-outline {
     &.btn-primary:not(:hover) {
@@ -48,5 +51,10 @@
     &.btn-danger:not(:hover) {
         background-color: transparent;
         color: @brand-danger;
+    }
+    
+    &.btn-light:not(:hover) {
+        background-color: transparent;
+        color: @gray-lightest;
     }
 }

--- a/ui-modules/utils/br-core/style/variables.less
+++ b/ui-modules/utils/br-core/style/variables.less
@@ -21,17 +21,17 @@
 @brand-accent: #bf3727;
 
 
-// Create path variables for fonts and images
-@br-core-path-font: '../fonts';
-@br-core-path-img: '../img';
-// Override the font-awesome path to use our custom one
-@fa-font-path: @br-core-path-font;
+// bootstrap colours at
+// https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_variables.scss
 
+@gray-light: #818899;   // override bootstrap default of #777
+@gray-lighter: #E1E5E7; // override bootstrap default of #eee
+@gray-lightest: #f8f8f9;
+@label-gray: darken(@gray-light, 10%);  // between @gray and @gray-light
 
-@body-bg: hsl(223,30%,97%);
+@body-bg: hsl(223,30%,97%);  // override bootstrap default, #333, same as @gray-dark, used for the button bar, body default bg colour from bootstrap scaffolding
+
 @card-border-color: mix(black, @body-bg, 7%);
-
-@font-family-sans-serif: "myriad-pro-1", Helvetica, Arial, sans-serif;
 
 /* Colors in pattern lab */
 .brand-primary {
@@ -54,3 +54,13 @@
 @state-accent-text:             @accent-500;
 @state-accent-bg:               @accent-30;
 @state-accent-border:           darken(spin(@state-accent-bg, -10), 5%);
+
+
+// Create path variables for fonts and images
+
+@br-core-path-font: '../fonts';
+@br-core-path-img: '../img';
+// Override the font-awesome path to use our custom one
+@fa-font-path: @br-core-path-font;
+
+@font-family-sans-serif: "myriad-pro-1", Helvetica, Arial, sans-serif;

--- a/ui-modules/utils/yaml-editor/addon/schemas/blueprint.json
+++ b/ui-modules/utils/yaml-editor/addon/schemas/blueprint.json
@@ -22,7 +22,6 @@
   "title": "Blueprint",
   "description": "A blueprint that is composed of one or more entities",
   "type": "object",
-  "required": [ "services" ],
   "properties": {
     "name": {
       "title": "Blueprint name",


### PR DESCRIPTION
* now supports map syntax in the visual editor (previously gave errors)
* now works without complaining if no services set
* leaves a marker in place if a location is removed (so consumers can avoid applying defaults or reset defaults)
* fixes bug where images broke during d3 transitions
* rationalises style files, moving similar things together and promoting some shareable things
