### PR TITLE
UI for defining parameters

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.template.html
@@ -52,7 +52,7 @@
              
               <div class="spacer" ng-repeat-start="filter in filters" ng-if="filter.spacerBefore"></div>
               <div class="nav-row-item" ng-repeat-end ng-click="filter.enabled = !filter.enabled">
-                <span title="{{ filter.hoverTest }}" class="label" ng-class="{'label-primary': filter.enabled, 'label-default': !filter.enabled }">
+                <span title="{{ filter.hoverText }}" class="label" ng-class="{'label-primary': filter.enabled, 'label-default': !filter.enabled }">
                     <i class="fa fa-{{ filter.icon }}" ng-if="filter.icon"></i>
                     <span ng-if="filter.label">{{ filter.label }}</span>
                 </span>

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -530,10 +530,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
     function addParameterDefinition(params, key) {
         params.push({
             "name": key,
-            "description": "",
             "type": "string",
-            "default": "",
-            "constraints": [],
         });
     }
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -83,6 +83,11 @@ export const CONFIG_FILTERS = [
     }
 ];
 
+export const PARAM_TYPES = [
+    // cut-down list from BasicSpecParameter.ParseYamlInputs
+    'string', 'boolean', 'integer', 'double', 'duration', ' port'
+    ];
+
 export function specEditorDirective($rootScope, $templateCache, $injector, $sanitize, $filter, $log, $sce, $timeout, $document, $state, $compile, blueprintService, composerOverrides) {
     return {
         restrict: 'E',
@@ -112,6 +117,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         scope.REPLACED_DSL_ENTITYSPEC = REPLACED_DSL_ENTITYSPEC;
         scope.parameters = [];
         scope.config = {};
+        specEditor.paramTypes = PARAM_TYPES;
 
         specEditor.getParameter = getParameter;
         specEditor.addParameter = addParameter;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -47,6 +47,8 @@ export const CONFIG_FILTERS = [
     {
         id: 'suggested',
         label: 'Suggested',
+        icon: 'plus-circle',
+        hoverText: 'Show config keys that marked as pinned or priority',
         filter: (item)=> {
             return item.pinned && item.priority > -1;
         }
@@ -54,6 +56,8 @@ export const CONFIG_FILTERS = [
     {
         id: 'required',
         label: 'Required',
+        icon: 'times-circle',
+        hoverText: 'Show config keys that are required or have an issue',
         filter: (item, model)=> {
             return (item.constraints && item.constraints.required) ||
                 (model && model.issues && model.issues.some((issue)=>(issue.group === 'config' && issue.ref === item.name)) );
@@ -62,6 +66,8 @@ export const CONFIG_FILTERS = [
     {
         id: 'inuse',
         label: 'In Use',
+        icon: 'check-circle',
+        hoverText: 'Show config keys that are in use',
         filter: (item, model)=> {
             return model && model.config && model.config.has(item.name);
         }
@@ -69,6 +75,8 @@ export const CONFIG_FILTERS = [
     {
         id: 'all',
         label: 'All',
+        icon: 'th-list',
+        hoverText: 'Show all config keys',
         filter: (item)=> {
             return item;
         }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -99,7 +99,6 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
 
     function link(scope, element, attrs, specEditor) {
         scope.specEditor = specEditor;
-        scope.addConfigKey = addConfigKey;
         scope.FAMILIES = EntityFamily;
         scope.RESERVED_KEYS = RESERVED_KEYS;
         scope.REPLACED_DSL_ENTITYSPEC = REPLACED_DSL_ENTITYSPEC;
@@ -783,6 +782,11 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 return config;
             });
         }
+        specEditor.getConfig = getConfig;
+        function getConfig(name) {
+            return scope.model.miscData.get('config').find(p => p.name === name);
+        }
+        
 
         function loadCustomConfigWidgetMetadata(model) {
             let customConfigWidgets = (scope.model.miscData.get('ui-composer-hints') || {})['config-widgets'] || [];
@@ -995,8 +999,8 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             scope.model.setConfigFromJson(result);
         }
 
-        function addConfigKey() {
-            let name = scope.state.config.add.value;
+        specEditor.addConfigKey = addConfigKey;
+        function addConfigKey(name) {
             if (name) {
                 let allConfig = scope.model.miscData.get('config');
                 blueprintService.addConfigKeyDefinition(allConfig, name);

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -664,7 +664,8 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                         JSON.parse(value);
                     } catch (notJson) {
                         // if not parseable or not a string, then convert to json
-                        value = JSON.stringify(value);
+                        // (as with other stringify, this loses any comments etc)
+                        value = JSON.stringify(value, null, "  ");
                     }
                     if (value != null) {
                         scope.state.parameters.edit.value = value;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -56,7 +56,7 @@ export const CONFIG_FILTERS = [
     {
         id: 'required',
         label: 'Required',
-        icon: 'times-circle',
+        icon: 'stop-circle',
         hoverText: 'Show config keys that are required or have an issue',
         filter: (item, model)=> {
             return (item.constraints && item.constraints.required) ||
@@ -241,7 +241,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         }, true);
 
         scope.getObjectSize = (object) => {
-            return specEditor.defined(object) && object != null ? Object.keys(object).length : 0;
+            return specEditor.defined(object) && object !== null ? Object.keys(object).length : 0;
         };
 
         function findNext(element, clazz, stopClazz) {
@@ -542,8 +542,6 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             else if (type === 'java.util.Map') type = 'map';
             else if (type === 'java.util.Set' || type === 'java.util.List' || type === 'java.util.Collection' || type.startsWith('List<')) type = 'array';
 
-            if (type.startsWith('AWS::')) type = 'unknown';
-
             return type;
         };
         scope.isCodeModeAvailable = (item) => {
@@ -559,7 +557,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             scope.state.config.codeModeForced[item.name] = false;
             // otherwise true if the text entered is json
             if (!specEditor.defined(val)) return false;
-            if (typeof val == 'string') {
+            if (typeof val === 'string') {
                 try {
                     // a YAML parse would be nicer, but JSON is simpler, and sufficient
                     // (esp as we export a JSON stringify; preferable would be to export the exact YAML from model,
@@ -593,7 +591,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             if (!specEditor.defined(value)) {
                 value = null;
             }
-            if (value != null) {
+            if (value !== null) {
                 if (oldMode) {
                     // leaving code mode
                     try {
@@ -638,12 +636,12 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                         value = JSON.stringify(value);
                     }
                 }
-                if (value != null) {
+                if (value !== null) {
                     scope.config[item.name] = value;
                 }
             }
             scope.state.config.codeModeActive[item.name] = !oldMode;
-            if (value != null) {
+            if (value !== null) {
                 // local config changed, make sure model is updated too
                 setModelFromLocalConfig();
             }
@@ -680,7 +678,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 }
                 // convert local parameter from json to non-json or vice-versa
                 value = item;
-                if (value != null) {
+                if (value !== null) {
                     try {
                         JSON.parse(value);
                     } catch (notJson) {
@@ -688,13 +686,13 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                         // (as with other stringify, this loses any comments etc)
                         value = JSON.stringify(value, null, "  ");
                     }
-                    if (value != null) {
+                    if (value !== null) {
                         scope.state.parameters.edit.json = value;
                     }
                 }
             }
             scope.state.parameters.codeModeActive[item.name] = !oldMode;
-            if (value != null) {
+            if (value !== null) {
                 // local parameters changed, make sure model is updated too
                 setModelFromLocalParameters();
             }
@@ -768,16 +766,16 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         };
         specEditor.isDsl = (key, index) => {
             let val = scope.model.config.get(key);
-            if (specEditor.defined(val) && specEditor.defined(index) && index != null) val = val[index];
+            if (specEditor.defined(val) && specEditor.defined(index) && index !== null) val = val[index];
             return specEditor.isDslVal(val);
         };
         specEditor.isDslVal = (val) => {
             // don't treat constants as DSL (not helpful, and the DSL editor doesn't support it)
-            return (val instanceof Dsl) && val.kind && val.kind.family != 'constant';
+            return (val instanceof Dsl) && val.kind && val.kind.family !== 'constant';
         };
         specEditor.isDslWizardButtonAllowed = (key, index, nonModelValue) => {
             let val = scope.model.config.get(key);
-            if (specEditor.defined(val) && specEditor.defined(index) && index != null) val = val[index];
+            if (specEditor.defined(val) && specEditor.defined(index) && index !== null) val = val[index];
             if (!specEditor.defined(val) || val === null || val === '') val = nonModelValue;
             if (!specEditor.defined(val) || val === null || val === '') return true;
             if (specEditor.isDslVal(val)) {
@@ -846,7 +844,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         }
 
         function getLocalConfigValueFromModelValue(key, value) {
-            if (!specEditor.defined(value) || value == null) {
+            if (!specEditor.defined(value) || value === null) {
                 return value;
             }
 
@@ -942,7 +940,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         }
 
         function getModelValueFromString(val) {
-            if (!specEditor.defined(val) || val == null || typeof val !== 'string') {
+            if (!specEditor.defined(val) || val === null || typeof val !== 'string') {
                 // only strings will have primitive inference applied
                 // (and this is only invoked when not in code mode)
                 return val;
@@ -1061,7 +1059,17 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         function loadLocalParametersFromModel() {
             let modelParams = scope.model.parameters;
             let result = [];
+            let dups = {};
             for (let paramRef of modelParams) {
+                if (dups[paramRef.name]) {
+                    var i=2;
+                    while (dups[paramRef.name+''+i]) i++;
+                    // users won't see this message (unless they have the console open) so it might be surprising
+                    // but other behaviours (like the UI breaking) are worse, and not sure of a simple better way to handle 
+                    $log.warn("Duplicate parameter '"+paramRef.name+"' found; changing to '"+paramRef.name+''+i+"'");
+                    paramRef.name = paramRef.name+''+i;
+                }
+                dups[paramRef.name] = true;
                 result.push(paramRef);
             }
             scope.parameters = result;
@@ -1075,7 +1083,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             if (!oldName) {
                 return true;
             }
-            if (oldName && oldName!=newName) {
+            if (oldName && oldName!==newName) {
                 scope.state.parameters.codeModeActive[newName] = scope.state.parameters.codeModeActive[oldName];
                 scope.state.parameters.codeModeError[newName] = scope.state.parameters.codeModeError[oldName]; 
                 delete scope.state.parameters.codeModeActive[oldName]; 
@@ -1127,18 +1135,18 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                             scope.state.parameters.edit.errors.push({ message: "Constraint JSON must be a list" });
                         }
                     } catch (e) {
-                        // $log.warn("ERROR parsing constraints", scope.state.parameters.edit.constraints, e);
+                        $log.warn("ERROR parsing constraints", scope.state.parameters.edit.constraints, e);
                         scope.state.parameters.edit.errors.push({ message: "Invalid constraint JSON" });
                     }
                     
                     // empty values are removed
-                    if (item.description == '') {
+                    if (item.description === '') {
                         delete item['description'];
                     } 
-                    if (item.label == '') {
+                    if (item.label === '') {
                         delete item['label'];
                     } 
-                    if (item.default == '') {
+                    if (item.default === '') {
                         if (scope.state.parameters.edit.original.default!=='') {
                             // don't delete if default was explicitly set in yaml as "";
                             // this allows empty string defaults to be used (although you can't set them in the visual ui)

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -391,6 +391,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 item: $item,
                 newName: $item.name,
                 constraints: $item.constraints ? JSON.stringify($item.constraints) : '',
+                original: Object.assign({}, $item),
                 json: JSON.stringify($item, null, "  "),
             };
         };
@@ -1109,10 +1110,34 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                     }
                      
                     try {
-                        item.constraints = JSON.parse(scope.state.parameters.edit.constraints);
+                        let c = scope.state.parameters.edit.constraints ? JSON.parse(scope.state.parameters.edit.constraints) : [];
+                        if (Array.isArray(c)) {
+                            if (c.length==0) { 
+                                delete item['constraints'];
+                            } else {
+                                item.constraints = c;
+                            }
+                        } else {
+                            scope.state.parameters.edit.errors.push({ message: "Constraint JSON must be a list" });
+                        }
                     } catch (e) {
                         // $log.warn("ERROR parsing constraints", scope.state.parameters.edit.constraints, e);
                         scope.state.parameters.edit.errors.push({ message: "Invalid constraint JSON" });
+                    }
+                    
+                    // empty values are removed
+                    if (item.description == '') {
+                        delete item['description'];
+                    } 
+                    if (item.label == '') {
+                        delete item['label'];
+                    } 
+                    if (item.default == '') {
+                        if (scope.state.parameters.edit.original.default!=='') {
+                            // don't delete if default was explicitly set in yaml as "";
+                            // this allows empty string defaults to be used (although you can't set them in the visual ui)
+                            delete item['default'];
+                        }
                     }
                 }
             }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -99,15 +99,16 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
 
     function link(scope, element, attrs, specEditor) {
         scope.specEditor = specEditor;
-        scope.getParameter = getParameter;
-        scope.addParameter = addParameter;
-        scope.removeParameter = removeParameter;
         scope.addConfigKey = addConfigKey;
         scope.FAMILIES = EntityFamily;
         scope.RESERVED_KEYS = RESERVED_KEYS;
         scope.REPLACED_DSL_ENTITYSPEC = REPLACED_DSL_ENTITYSPEC;
         scope.parameters = [];
         scope.config = {};
+
+        specEditor.getParameter = getParameter;
+        specEditor.addParameter = addParameter;
+        specEditor.removeParameter = removeParameter;
 
         let defaultState = {
             parameters: {
@@ -415,7 +416,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             $state.go(graphicalState.name);
         };
 
-        scope.getParameterIssues = specEditor.getParameterIssues = () => {
+        specEditor.getParameterIssues = () => {
             return scope.model.issues
                 .filter((issue) => (issue.group === 'parameters'))
                 .concat(Object.values(scope.model.getClusterMemberspecEntities())
@@ -520,7 +521,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             }
             return item.widgetMode;
         };
-        scope.getParameterWidgetMode = (item) => {
+        specEditor.getParameterWidgetMode = (item) => {
             let type = item.type || item.typeName;
 
             if (type === 'java.lang.Boolean') type = 'boolean';
@@ -700,10 +701,13 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 // show the error if manually enabled
                 return widgetMetadata["error"];
             }
+            return null;
+        };
+        specEditor.customParameterErrors = (item) => {
             if (scope.state.parameters && scope.state.parameters.edit && scope.state.parameters.edit.item === item && scope.state.parameters.edit.errors) {
                 return scope.state.parameters.edit.errors;
             }
-            return null;
+            return [];
         };
         specEditor.toggleCustomConfigWidgetMode = (item, newval) => {
             let widgetMetadata = scope.state.config.customConfigWidgetMetadata[item.name];
@@ -1051,6 +1055,9 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         }
 
         function checkNameChange(oldName, newName) {
+            if (!oldName) {
+                return true;
+            }
             if (oldName && oldName!=newName) {
                 scope.state.parameters.codeModeActive[newName] = scope.state.parameters.codeModeActive[oldName];
                 scope.state.parameters.codeModeError[newName] = scope.state.parameters.codeModeError[oldName]; 
@@ -1109,18 +1116,15 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             scope.model.setParametersFromJson(result);
         }
 
-        function addParameter() {
-            let name = scope.state.parameters.add.value;
-            if (name) {
-                let allParams = scope.model.miscData.get('parameters');
-                blueprintService.addParameterDefinition(allParams, name);
-                let param = allParams.find(p => p.name === name);
-                scope.model.addParameter(param);
-                loadLocalParametersFromModel();
-                scope.state.parameters.add.value = '';
-                scope.state.parameters.add.open = false;
-                scope.state.parameters.focus = name;
-            }
+        function addParameter(name) {
+            let allParams = scope.model.miscData.get('parameters');
+            blueprintService.addParameterDefinition(allParams, name);
+            let param = allParams.find(p => p.name === name);
+            scope.model.addParameter(param);
+            loadLocalParametersFromModel();
+            scope.state.parameters.add.value = '';
+            scope.state.parameters.add.open = false;
+            scope.state.parameters.focus = name;
         }
 
         function removeParameter(name) {

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -833,22 +833,28 @@ spec-editor {
 
     .spec-configuration-filters-categories {
       overflow: hidden;
-      list-style: none;
       padding: 0;
-      li {
+      display: flex;
+      div.filter {
         cursor: pointer;
+        margin-top: 4px;
+        margin-bottom: 4px;
         &:not(:first-child) {
-          margin-left: 1.5em;
+          margin-left: 1em;
         }
-        .filter-checkbox {
-          width: 1em;
+        &:last-child {
+          flex-grow: 1;
+          text-align: right;
         }
-        &.disabled {
-          color: @gray-light;
-          cursor: inherit;
+        .filter-icon {
+          width: 2ex;
+          text-align: left;
+        }
+        label {
+          padding-left: 1em;
+          padding-right: 1em;
         }
       }
-      color: @gray;
     }
   }
   .spec-configuration-filters .form-group, .spec-parameter-filters .form-group {

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -837,6 +837,10 @@ spec-editor {
   a.open-entity-spec {
     cursor: alias;
   }
+  &.parameters {
+    .control-value {
+    }
+  }
 }
 
 .popover.spec-editor-popover {

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -869,6 +869,10 @@ spec-editor {
         margin-top: 6px;
     }
    }
+   .param-error-footer {
+        width: 100%;
+        order: 99;
+   }
   }
 }
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -241,10 +241,13 @@ spec-editor {
       padding-top: 10px;
       border-top: 1px solid @gray-lighter;
 
-      &:first-child {
+      &:first-child, &.spec-add-button, &.config-add-button {
         margin-top: 0;
         padding-top: 0;
         border: none;
+      }
+      &.spec-add-button, &.config-add-button {
+        text-align: right;
       }
     }
 
@@ -799,14 +802,15 @@ spec-editor {
     }
   }
   
+  .spec-parameter-filters,
   .spec-configuration-filters,
   .spec-configuration-add {
     background: @gray-lighter;
     border: 1px solid @gray-light;
     transition: 0.15s ease all;
     padding: 0.5em;
-    margin-top: -12px;
-    margin-bottom: 24px;
+    margin-top: -4px;
+    margin-bottom: 16px;
     .dropdown-menu li a {
         // quite a lot of padding in normal dropdown, in the ul and in the a
         padding: 0;
@@ -847,7 +851,7 @@ spec-editor {
       color: @gray;
     }
   }
-  .spec-configuration-filters .form-group {
+  .spec-configuration-filters .form-group, .spec-parameter-filters .form-group {
     margin-bottom: 5px;
     &:last-child {
       margin-bottom: 0;  // get padding from parent

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -456,6 +456,30 @@ spec-editor {
             }
         }
     }
+    .param-fields {
+        width: 100%;
+        margin-top: 8px;
+        margin-bottom: 3px;
+        display: flex;
+        flex-direction: column;
+    }
+    .param-field {
+        display: flex;
+        margin-top: 2px;
+        flex-direction: row;
+        .param-field-label {
+            color: @gray-light;
+            width: 9em;
+            font-size: 90%;
+            padding-top: 3px;
+        }
+        .param-field-value {
+            width: 100%;
+            textarea.code {
+                .monospace();
+            }
+        }
+    }
     .form-group:hover, .form-group:focus, .form-group:focus-within {
         .control-label .info-spec-configuration {
             visibility: visible;
@@ -837,9 +861,14 @@ spec-editor {
   a.open-entity-spec {
     cursor: alias;
   }
-  &.parameters {
+  .parameters {
+   .form-group:focus-within, .form-group:focus {
     .control-value {
+        border-top: solid #aaaaaa 1px;   // TODO pull #aaaaaa out into shared colours file (follow-on PR)
+        padding-top: 1px;
+        margin-top: 6px;
     }
+   }
   }
 }
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -472,9 +472,14 @@ spec-editor {
         flex-direction: row;
         .param-field-label {
             color: @gray-light;
-            width: 9em;
+            width: 10em;
             font-size: 90%;
             padding-top: 3px;
+            > i.fa-info-circle {
+                float: right;
+                margin-top: 4px;
+                margin-right: 4px;
+            }
         }
         .param-field-value {
             width: 100%;
@@ -803,14 +808,9 @@ spec-editor {
   }
   
   .spec-parameter-filters,
+  .spec-configuration.parameters,
   .spec-configuration-filters,
   .spec-configuration-add {
-    background: @gray-lighter;
-    border: 1px solid @gray-light;
-    transition: 0.15s ease all;
-    padding: 0.5em;
-    margin-top: -4px;
-    margin-bottom: 16px;
     .dropdown-menu li a {
         // quite a lot of padding in normal dropdown, in the ul and in the a
         padding: 0;
@@ -821,6 +821,17 @@ spec-editor {
             margin-right: 1ex;
         }
     }
+  }
+  
+  .spec-parameter-filters,
+  .spec-configuration-filters,
+  .spec-configuration-add {
+    background: @gray-lighter;
+    border: 1px solid @gray-light;
+    transition: 0.15s ease all;
+    padding: 0.5em;
+    margin-top: -4px;
+    margin-bottom: 16px;
 
     legend {
       color: @gray;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -102,7 +102,7 @@
     </fieldset>
 
     <div class="spec-configuration parameters">
-        <div class="spec-empty-state" ng-if="filteredItems.length === 0">
+        <div class="spec-empty-state" ng-if="filteredParams.length === 0">
             <div ng-if="parameters.length === 0">
                 <h4>No parameters</h4>
             </div>
@@ -118,8 +118,8 @@
         </div>
 
         <form name="formSpecParameter" novalidate class="lightweight">
-            <div ng-repeat="item in (filteredItems = (model.parameters | filter:{name:state.parameters.search} | orderBy:+priority)) track by item.name ">
-                <div class="form-group" ng-class="{'has-error': (model.issues | filter:{ref: item.name}:true).length > 0, 'used': getParameter(item.name) !== undefined}"
+            <div ng-repeat="item in (filteredParams = (model.parameters | filter:{name:state.parameters.search} | orderBy:+priority)) track by item.name">
+                <div class="form-group" ng-class="{'has-error': ((model.issues | filter:{ref: item.name}:true).length > 0) || (specEditor.customConfigWidgetError(item)), 'used': getParameter(item.name) !== undefined}"
                      ng-switch="getParameterWidgetMode(item)"
                      tabindex="1"
                      auto-focus="state.parameters.focus === item.name"
@@ -155,16 +155,70 @@
                         <div class="control-value" ng-class="{ 'code-mode-active': state.parameters.codeModeActive[item.name] }">
                           <div class="input-group hide-when-collapsed" ng-if="state.parameters.codeModeActive[item.name]">
                             <span class="main-control span-for-rounded-edge">
-                                <textarea ng-model="state.parameters.edit.value" class="form-control rounded-edge" name="{{item.name}}" id="{{item.name}}"
+                                <textarea ng-model="state.parameters.edit.json" class="form-control rounded-edge" name="{{item.name}}" id="json-{{item.name}}"
                                           auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel"></textarea>
                             </span>
                           </div>
                           
-                          <div class="input-group" ng-if="!state.parameters.codeModeActive[item.name]">
+                          <div class="param-fields input-group hide-when-collapsed" ng-if="!state.parameters.codeModeActive[item.name]">
+                            <div class="param-field"> <span class="param-field-label">Key</span> 
+                                <span class="param-field-value">
+                                    <textarea ng-model="state.parameters.edit.newName" class="form-control rounded-edge" id="name-{{item.name}}"
+                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          on-enter="specEditor.advanceOutToFormGroupInPanel">
+                                    </textarea>
+                                </span>
+                            </div>
+                            <div class="param-field"> <span class="param-field-label">Type</span> 
+                                <span class="param-field-value">
+                                    <textarea ng-model="filteredParams[$index].type" class="form-control rounded-edge" id="type-{{item.name}}"
+                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          on-enter="specEditor.advanceOutToFormGroupInPanel">
+                                    </textarea>
+                                </span>
+                            </div>
+                            <div class="param-field"> <span class="param-field-label">Default value</span> 
+                                <span class="param-field-value">
+                                    <textarea ng-model="filteredParams[$index].default" class="form-control rounded-edge" id="default-{{item.name}}"
+                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          on-enter="specEditor.advanceOutToFormGroupInPanel">
+                                    </textarea>
+                                </span>
+                            </div>
+                            <div class="param-field"> <span class="param-field-label">Display name</span> 
+                                <span class="param-field-value">
+                                    <textarea ng-model="filteredParams[$index].label" class="form-control rounded-edge" id="label-{{item.name}}"
+                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          on-enter="specEditor.advanceOutToFormGroupInPanel">
+                                    </textarea>
+                                </span>
+                            </div>
+                            <div class="param-field"> <span class="param-field-label">Description</span> 
+                                <span class="param-field-value">
+                                    <textarea ng-model="filteredParams[$index].description" class="form-control rounded-edge" id="description-{{item.name}}"
+                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          on-enter="specEditor.advanceOutToFormGroupInPanel">
+                                    </textarea>
+                                </span>
+                            </div>
+                            <div class="param-field"> <span class="param-field-label">Constraints
+                                    <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
+                                           uib-popover="Constraints such as required or forbiddenUnless(otherKey), expressed as a JSON list (wrapped in brackets)"
+                                           x-popover-class="spec-editor-popover" 
+                                           popover-placement="top-left" popover-append-to-body="true"></i>
+                                </span> 
+                                <span class="param-field-value">
+                                    <textarea ng-model="state.parameters.edit.constraints" class="form-control rounded-edge code" id="constraints-{{item.name}}"
+                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          on-enter="specEditor.advanceOutToFormGroupInPanel">
+                                    </textarea>
+                                </span>
+                            </div>
                           </div>
                         </div>
 
+                        <small ng-if="state.parameters.edit.item === item" ng-repeat="issue in state.parameters.edit.errors" class="help-block issue" ng-bind-html="issue.message"></small>
                         <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
                     </div>
                 </div>

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -233,14 +233,18 @@
             <input ng-model="state.config.search" type="text" class="form-control" placeholder="Search for config key by name" auto-focus="state.config.filter.open" blur-on-enter />
         </div>
         <div class="form-group">
-            <ul class="spec-configuration-filters-categories">
-                <li ng-repeat="filter in filters.config track by filter.id"
+            <div class="spec-configuration-filters-categories">
+                <div ng-repeat="filter in filters.config track by filter.id"
                     ng-class="{ 'disabled': isFilterDisabled(filter) }"
                     ng-click="onFilterClicked(filter)"
-                    class="pull-left">
-                    <i class="filter-checkbox fa" ng-class="{'fa-check-square-o': state.config.filter.values[ filter.id ], 'fa-square-o': !state.config.filter.values[ filter.id ]}"></i> {{filter.label}}
-                </li>
-            </ul>
+                    class="filter">
+                    
+                    <span title="{{ filter.hoverText }}" class="label" ng-class="{'label-primary': state.config.filter.values[ filter.id ], 'label-default': !state.config.filter.values[ filter.id ] }">
+                        <i class="filter-icon fa fa-{{ filter.icon }}" ng-if="filter.icon"></i>
+                        <span class="filter-label" ng-if="filter.label">{{ filter.label }}</span>
+                    </span>
+                </div>
+            </div>
         </div>
     </fieldset>
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -144,7 +144,12 @@
                           </div>
                           
                           <div class="param-fields input-group hide-when-collapsed" ng-if="!state.parameters.codeModeActive[item.name]">
-                            <div class="param-field"> <span class="param-field-label">Key</span> 
+                            <div class="param-field"> <span class="param-field-label">Key
+                                    <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
+                                           uib-popover="The internal name of this parameter and of the config key it becomes on deployment."
+                                           x-popover-class="spec-editor-popover" 
+                                           popover-placement="top-left" popover-append-to-body="true"></i>
+                                </span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="state.parameters.edit.newName" class="form-control rounded-edge" id="name-{{item.name}}"
                                           auto-grow 
@@ -154,17 +159,29 @@
                                     </textarea>
                                 </span>
                             </div>
-                            <div class="param-field"> <span class="param-field-label">Type</span> 
+                            <div class="param-field"> <span class="param-field-label">Type
+                                    <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
+                                           uib-popover="The type of the value this key takes, such as 'integer' or 'double' for numbers or 'string' for freeform text."
+                                           x-popover-class="spec-editor-popover" 
+                                           popover-placement="top-left" popover-append-to-body="true"></i>
+                                </span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].type" class="form-control rounded-edge" id="type-{{item.name}}"
                                           auto-grow 
                                           placeholder="(required)" 
+                                          uib-typeahead="t for t in specEditor.paramTypes | filter:$viewValue"
+                                          typeahead-min-length="0"
                                           ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel">
                                     </textarea>
                                 </span>
                             </div>
-                            <div class="param-field"> <span class="param-field-label">Default value</span> 
+                            <div class="param-field"> <span class="param-field-label">Default value
+                                    <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
+                                           uib-popover="Optionally a value can be given here to use for this parameter if one is not supplied by the user. An empty string supplied here will cause the default to be removed. (Empty strings can be set explicitly in the underlying YAML code if required.)"
+                                           x-popover-class="spec-editor-popover" 
+                                           popover-placement="top-left" popover-append-to-body="true"></i>
+                                </span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].default" class="form-control rounded-edge" id="default-{{item.name}}"
                                           auto-grow 
@@ -174,7 +191,12 @@
                                     </textarea>
                                 </span>
                             </div>
-                            <div class="param-field"> <span class="param-field-label">Display name</span> 
+                            <div class="param-field"> <span class="param-field-label">Display name
+                                    <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
+                                           uib-popover="Optional label displayed in places to be more user-friendly than the parameter/key name. This can have spaces whereas the name should not."
+                                           x-popover-class="spec-editor-popover" 
+                                           popover-placement="top-left" popover-append-to-body="true"></i>
+                                </span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].label" class="form-control rounded-edge" id="label-{{item.name}}"
                                           auto-grow 
@@ -184,7 +206,12 @@
                                     </textarea>
                                 </span>
                             </div>
-                            <div class="param-field"> <span class="param-field-label">Description</span> 
+                            <div class="param-field"> <span class="param-field-label">Description
+                                    <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
+                                           uib-popover="Optional information on what this parameter is for, displayed to the user in the UI"
+                                           x-popover-class="spec-editor-popover" 
+                                           popover-placement="top-left" popover-append-to-body="true"></i>
+                                </span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].description" class="form-control rounded-edge" id="description-{{item.name}}"
                                           auto-grow 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -53,10 +53,10 @@
 
 
 <!-- ENTITY PARAMETERS -->
-<br-collapsible ng-if="true" state="state.parameters.open">  <!-- the ng-if is needed to make state update?! -->
+<br-collapsible state="state.parameters.open" ng-if="!model.parent">  <!-- the ng-if is needed to make state update?! -->
     <heading>
         Parameters
-        <span ng-if="getParameterIssues().length> 0" class="badge" ng-class="getBadgeClass(getParameterIssues())">{{getParameterIssues().length}}</span>
+        <span ng-if="specEditor.getParameterIssues().length> 0" class="badge" ng-class="getBadgeClass(specEditor.getParameterIssues())">{{specEditor.getParameterIssues().length}}</span>
         <span class="pull-right" ng-show="$parent.stateWrapped.state">
             <span class="spec-toolbar-action" ng-class="{'active': state.parameters.filter.open}"><i class="fa fa-filter collapsible-action" title="Filter parameters" ng-click="$event.stopPropagation(); $event.preventDefault(); state.parameters.filter.open = !state.parameters.filter.open" ng-class="{'text-info': state.parameters.search.length > 0}"></i></span>
             <span class="spec-toolbar-action"><i class="fa fa-plus collapsible-action" title="Add parameter" ng-click="$event.stopPropagation(); $event.preventDefault(); state.parameters.add.open = !state.parameters.add.open"></i></span>
@@ -89,7 +89,7 @@
         <div ng-if="state.parameters.add.value.length > 0 && noResults" uib-dropdown uib-dropdown-toggle auto-close="disabled" is-open="true">
             <ul class="dropdown-menu">
                 <!-- mimic real dropdown if nothing found -->
-                <li class="uib-typeahead-match"><a ng-click="addParameter()">
+                <li class="uib-typeahead-match"><a ng-click="specEditor.addParameter(state.parameters.add.value)">
                     <div class="dropdown-item" ng-init="item = match.model">
                         <div class="dropdown-row">
                             <span ng-bind-html="state.parameters.add.value | uibTypeaheadHighlight:query" class="config-name"></span>
@@ -105,22 +105,27 @@
         <div class="spec-empty-state" ng-if="filteredParams.length === 0">
             <div ng-if="parameters.length === 0">
                 <h4>No parameters</h4>
+                <p class="buttons">
+                    <button class="btn btn-sm btn-success" ng-click="specEditor.addParameter(state.parameters.search)">
+                        <i class="fa fa-plus"></i> Add parameter
+                    </button>
+                </p>
             </div>
             <div ng-if="parameters.length > 0">
                 <h4>No matching parameters</h4>
                 <p class="buttons">
                     <button class="btn btn-sm btn-default" ng-if="state.parameters.search.length > 0" ng-click="state.parameters.search = ''">Clear search</button>
-                    <button class="btn btn-sm btn-success" ng-if="!state.parameters.filter.values.all" ng-click="state.parameters.filter.values.all = true">
-                        <i class="fa fa-filter"></i> Display all parameter options
+                    <button class="btn btn-sm btn-success" ng-click="specEditor.addParameter(state.parameters.search)">
+                        <i class="fa fa-plus"></i> Add '{{state.parameters.search}}'
                     </button>
                 </p>
             </div>
         </div>
 
         <form name="formSpecParameter" novalidate class="lightweight">
-            <div ng-repeat="item in (filteredParams = (model.parameters | filter:{name:state.parameters.search} | orderBy:+priority)) track by item.name">
-                <div class="form-group" ng-class="{'has-error': ((model.issues | filter:{ref: item.name}:true).length > 0) || (specEditor.customConfigWidgetError(item)), 'used': getParameter(item.name) !== undefined}"
-                     ng-switch="getParameterWidgetMode(item)"
+            <div ng-repeat="item in (filteredParams = (model.parameters | filter:{name:state.parameters.search})) track by item.name">
+                <div class="form-group"
+                     ng-switch="specEditor.getParameterWidgetMode(item)"
                      tabindex="1"
                      auto-focus="state.parameters.focus === item.name"
                      auto-focus-listen-to-window="true"
@@ -146,8 +151,8 @@
                                    title="{{state.parameters.codeModeActive[item.name] ? 'Set' : 'Edit'}} value as a JSON-encoded object [{{item.name}}]"></i>
                                 <span class="sr-only">Edit value as a JSON-encoded object [{{item.name}}]</span>
                             </span>
-                            <span class="remove-spec-configuration" ng-if="getParameter(item.name) !== undefined">
-                                <i class="fa fa-fw fa-trash" ng-click="removeParameter(item.name)" aria-hidden="true" title="Remove parameter {{item.name}}"></i>
+                            <span class="remove-spec-configuration" ng-if="specEditor.getParameter(item.name) !== undefined">
+                                <i class="fa fa-fw fa-trash" ng-click="specEditor.removeParameter(item.name)" aria-hidden="true" title="Remove parameter {{item.name}}"></i>
                                 <span class="sr-only">Remove parameter {{item.name}}</span>
                             </span>
                         </span>
@@ -218,8 +223,10 @@
                           </div>
                         </div>
 
-                        <small ng-if="state.parameters.edit.item === item" ng-repeat="issue in state.parameters.edit.errors" class="help-block issue" ng-bind-html="issue.message"></small>
-                        <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
+                        <div class="has-error param-error-footer">
+                            <small ng-if="state.parameters.edit.item === item" ng-repeat="issue in state.parameters.edit.errors" class="help-block issue" ng-bind-html="issue.message"></small>
+                            <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true | filter:{group: 'parameter'}:true" class="help-block issue" ng-bind-html="issue.message"></small>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -303,7 +310,7 @@
 
         <form name="formSpecConfig" novalidate class="lightweight">
             <div ng-repeat="item in (filteredItems = (model.miscData.get('config') | specEditorConfig:state.config.filter.values:model | filter:{name:state.config.search} | orderBy:+priority)) track by item.name ">
-                <div class="form-group" ng-class="{'has-error': ((model.issues | filter:{ref: item.name}:true).length > 0) || (specEditor.customConfigWidgetError(item)), 'used': config[item.name] !== undefined}" 
+                <div class="form-group" ng-class="{'has-error': ((model.issues | filter:{ref: item.name}:true | filter:{group: 'config'}:true).length > 0) || (specEditor.customConfigWidgetError(item)), 'used': config[item.name] !== undefined}" 
                         ng-switch="getConfigWidgetMode(item)" 
                         tabindex="1"
                         auto-focus="state.config.focus === item.name"
@@ -507,7 +514,7 @@
                         
                     </div>
                     
-                    <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
+                    <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true | filter:{group: 'config'}:true" class="help-block issue" ng-bind-html="issue.message"></small>
                     <small ng-if="specEditor.customConfigWidgetError(item)" class="help-block issue">
                             Custom widget unavailable:
                             {{ specEditor.customConfigWidgetError(item) }}

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -223,7 +223,7 @@
                             </div>
                             <div class="param-field"> <span class="param-field-label">Constraints
                                     <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
-                                           uib-popover="Constraints such as &quot;required&quot; or &quot;forbiddenUnless(otherKey)&quot;, expressed as a JSON list (wrapped in square brackets)"
+                                           uib-popover="Constraints such as &quot;required&quot; or &quot;forbiddenUnless(otherKey)&quot;, expressed as a JSON list (wrapped in square brackets and double quotes)"
                                            x-popover-class="spec-editor-popover" 
                                            popover-placement="top-left" popover-append-to-body="true"></i>
                                 </span> 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -58,50 +58,25 @@
         Parameters
         <span ng-if="specEditor.getParameterIssues().length> 0" class="badge" ng-class="getBadgeClass(specEditor.getParameterIssues())">{{specEditor.getParameterIssues().length}}</span>
         <span class="pull-right" ng-show="$parent.stateWrapped.state">
-            <span class="spec-toolbar-action" ng-class="{'active': state.parameters.filter.open}"><i class="fa fa-filter collapsible-action" title="Filter parameters" ng-click="$event.stopPropagation(); $event.preventDefault(); state.parameters.filter.open = !state.parameters.filter.open" ng-class="{'text-info': state.parameters.search.length > 0}"></i></span>
-            <span class="spec-toolbar-action"><i class="fa fa-plus collapsible-action" title="Add parameter" ng-click="$event.stopPropagation(); $event.preventDefault(); state.parameters.add.open = !state.parameters.add.open"></i></span>
+            <span class="spec-toolbar-action" ng-class="{'active': state.parameters.filter.open}"><i class="fa fa-search-plus collapsible-action" title="Search or add a parameter" ng-click="$event.stopPropagation(); $event.preventDefault(); state.parameters.filter.open = !state.parameters.filter.open" ng-class="{'text-info': state.parameters.search.length > 0}"></i></span>
         </span>
     </heading>
 
-    <fieldset uib-collapse="!state.parameters.filter.open" class="spec-configuration-filters">
+    <fieldset uib-collapse="!state.parameters.filter.open" class="spec-parameter-filters">
         <div class="form-group">
-            <input ng-model="state.parameters.search" type="text" class="form-control" placeholder="Search for parameter by name" auto-focus="state.parameters.filter.open" blur-on-enter />
-        </div>
-    </fieldset>
-
-    <fieldset uib-collapse="!state.parameters.add.open" class="spec-configuration-add">
-        <input auto-focus="state.parameters.add.open"
-               type="text"
-               autocomplete="off"
-               ng-model="state.parameters.add.value"
-               placeholder="Add a new parameter or open existing"
-               class="form-control"
-               uib-typeahead="parameter.name for parameter in state.parameters.add.list | filter:{name:$viewValue}"
-               typeahead-template-url="blueprint-composer/component/spec-editor/parameter-item.html"
-               typeahead-editable="true"
-               typeahead-show-hint="true"
-               typeahead-min-length="0"
-               typeahead-select-on-blur="true"
-               typeahead-on-select="onFocusOnParameter($item, $model, $label, $event)"
-               typeahead-no-results="noResults"
-               blur-on-enter />
-
-        <div ng-if="state.parameters.add.value.length > 0 && noResults" uib-dropdown uib-dropdown-toggle auto-close="disabled" is-open="true">
-            <ul class="dropdown-menu">
-                <!-- mimic real dropdown if nothing found -->
-                <li class="uib-typeahead-match"><a ng-click="specEditor.addParameter(state.parameters.add.value)">
-                    <div class="dropdown-item" ng-init="item = match.model">
-                        <div class="dropdown-row">
-                            <span ng-bind-html="state.parameters.add.value | uibTypeaheadHighlight:query" class="config-name"></span>
-                            <i class="fa fa-fw fa-plus-square-o"></i>
-                        </div>
-                    </div>
-                </a></li>
-            </ul>
+            <input auto-focus="state.parameters.filter.open" 
+                type="text"
+                autocomplete="off" 
+                ng-model="state.parameters.search" 
+                placeholder="Search or add a parameter" 
+                class="form-control"
+                blur-on-enter 
+                />
         </div>
     </fieldset>
 
     <div class="spec-configuration parameters">
+
         <div class="spec-empty-state" ng-if="filteredParams.length === 0">
             <div ng-if="parameters.length === 0">
                 <h4>No parameters</h4>
@@ -121,7 +96,7 @@
                 </p>
             </div>
         </div>
-
+    
         <form name="formSpecParameter" novalidate class="lightweight">
             <div ng-repeat="item in (filteredParams = (model.parameters | filter:{name:state.parameters.search})) track by item.name">
                 <div class="form-group"
@@ -231,6 +206,15 @@
                 </div>
             </div>
         </form>
+        
+        <div class="spec-add-button" ng-if="filteredParams.length > 0 && state.parameters.search && !specEditor.getParameter(state.parameters.search)">
+                <p class="buttons">
+                    <button class="btn btn-sm btn-success" ng-click="specEditor.addParameter(state.parameters.search)">
+                        <i class="fa fa-plus"></i> Add '{{state.parameters.search}}'
+                    </button>
+                </p>
+        </div>
+        
     </div>
 </br-collapsible>
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -136,7 +136,9 @@
                           <div class="input-group hide-when-collapsed" ng-if="state.parameters.codeModeActive[item.name]">
                             <span class="main-control span-for-rounded-edge">
                                 <textarea ng-model="state.parameters.edit.json" class="form-control rounded-edge" name="{{item.name}}" id="json-{{item.name}}"
-                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          auto-grow 
+                                          placeholder="(required)" 
+                                          ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel"></textarea>
                             </span>
                           </div>
@@ -145,7 +147,9 @@
                             <div class="param-field"> <span class="param-field-label">Key</span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="state.parameters.edit.newName" class="form-control rounded-edge" id="name-{{item.name}}"
-                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          auto-grow 
+                                          placeholder="(required)" 
+                                          ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel">
                                     </textarea>
                                 </span>
@@ -153,7 +157,9 @@
                             <div class="param-field"> <span class="param-field-label">Type</span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].type" class="form-control rounded-edge" id="type-{{item.name}}"
-                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          auto-grow 
+                                          placeholder="(required)" 
+                                          ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel">
                                     </textarea>
                                 </span>
@@ -161,7 +167,9 @@
                             <div class="param-field"> <span class="param-field-label">Default value</span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].default" class="form-control rounded-edge" id="default-{{item.name}}"
-                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          auto-grow 
+                                          placeholder="{{ state.parameters.edit.original.default == '' ? '(empty)' : '(not set)' }}" 
+                                          ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel">
                                     </textarea>
                                 </span>
@@ -169,7 +177,9 @@
                             <div class="param-field"> <span class="param-field-label">Display name</span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].label" class="form-control rounded-edge" id="label-{{item.name}}"
-                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          auto-grow 
+                                          placeholder="(not set)" 
+                                          ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel">
                                     </textarea>
                                 </span>
@@ -177,20 +187,24 @@
                             <div class="param-field"> <span class="param-field-label">Description</span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="filteredParams[$index].description" class="form-control rounded-edge" id="description-{{item.name}}"
-                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          auto-grow 
+                                          placeholder="(not set)" 
+                                          ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel">
                                     </textarea>
                                 </span>
                             </div>
                             <div class="param-field"> <span class="param-field-label">Constraints
                                     <i class="fa fa-fw fa-info-circle" popover-trigger="'mouseenter'"
-                                           uib-popover="Constraints such as required or forbiddenUnless(otherKey), expressed as a JSON list (wrapped in brackets)"
+                                           uib-popover="Constraints such as &quot;required&quot; or &quot;forbiddenUnless(otherKey)&quot;, expressed as a JSON list (wrapped in square brackets)"
                                            x-popover-class="spec-editor-popover" 
                                            popover-placement="top-left" popover-append-to-body="true"></i>
                                 </span> 
                                 <span class="param-field-value">
                                     <textarea ng-model="state.parameters.edit.constraints" class="form-control rounded-edge code" id="constraints-{{item.name}}"
-                                          auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
+                                          auto-grow 
+                                          placeholder="(none)"
+                                          ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel">
                                     </textarea>
                                 </span>

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -252,6 +252,11 @@
         <div class="spec-empty-state" ng-if="filteredItems.length === 0">
           <div ng-if="model.miscData.get('config').length === 0">
             <h4>No configuration</h4>
+            <p class="buttons">
+                <button class="btn btn-sm btn-success" ng-click="specEditor.addConfigKey(state.config.search)" ng-if="state.config.search">
+                        <i class="fa fa-plus"></i> Add '{{state.config.search}}'
+                </button>
+            </p>
           </div>
           <div ng-if="model.miscData.get('config').length > 0">
             <h4>No matching configuration</h4>

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -101,7 +101,7 @@
         </div>
     </fieldset>
 
-    <div class="spec-configuration">
+    <div class="spec-configuration parameters">
         <div class="spec-empty-state" ng-if="filteredItems.length === 0">
             <div ng-if="parameters.length === 0">
                 <h4>No parameters</h4>
@@ -152,12 +152,17 @@
                             </span>
                         </span>
 
-                        <div class="input-group" ng-if="state.parameters.codeModeActive[item.name]">
+                        <div class="control-value" ng-class="{ 'code-mode-active': state.parameters.codeModeActive[item.name] }">
+                          <div class="input-group hide-when-collapsed" ng-if="state.parameters.codeModeActive[item.name]">
                             <span class="main-control span-for-rounded-edge">
                                 <textarea ng-model="state.parameters.edit.value" class="form-control rounded-edge" name="{{item.name}}" id="{{item.name}}"
                                           auto-grow placeholder="(empty)" ng-focus="specEditor.recordParameterFocus(item)"
                                           on-enter="specEditor.advanceOutToFormGroupInPanel"></textarea>
                             </span>
+                          </div>
+                          
+                          <div class="input-group" ng-if="!state.parameters.codeModeActive[item.name]">
+                          </div>
                         </div>
 
                         <small ng-repeat="issue in model.issues | filter:{ref: item.name}:true" class="help-block issue" ng-bind-html="issue.message"></small>
@@ -226,7 +231,7 @@
         </div>
     </fieldset>
 
-    <div class="spec-configuration">
+    <div class="spec-configuration config">
         <div class="spec-empty-state" ng-if="filteredItems.length === 0">
           <div ng-if="model.miscData.get('config').length === 0">
             <h4>No configuration</h4>

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -224,8 +224,7 @@
         Configuration
         <span ng-if="getConfigIssues().length> 0" class="badge" ng-class="getBadgeClass(getConfigIssues())">{{getConfigIssues().length}}</span>
         <span class="pull-right" ng-show="$parent.stateWrapped.state">
-            <span class="spec-toolbar-action" ng-class="{'active': state.config.filter.open}"><i class="fa fa-filter collapsible-action" title="Filter configuration" ng-click="$event.stopPropagation(); $event.preventDefault(); state.config.filter.open = !state.config.filter.open" ng-class="{'text-info': state.config.search.length > 0}"></i></span>
-            <span class="spec-toolbar-action"><i class="fa fa-plus collapsible-action" title="Add configuration" ng-click="$event.stopPropagation(); $event.preventDefault(); state.config.add.open = !state.config.add.open"></i></span>
+            <span class="spec-toolbar-action" ng-class="{'active': state.config.filter.open}"><i class="fa fa-search-plus collapsible-action" title="Filter configuration" ng-click="$event.stopPropagation(); $event.preventDefault(); state.config.filter.open = !state.config.filter.open" ng-class="{'text-info': state.config.search.length > 0}"></i></span>
         </span>
     </heading>
 
@@ -245,37 +244,6 @@
         </div>
     </fieldset>
 
-    <fieldset uib-collapse="!state.config.add.open" class="spec-configuration-add">
-        <input auto-focus="state.config.add.open"
-             type="text"
-             autocomplete="off"
-             ng-model="state.config.add.value"
-             placeholder="Add a new configuration key or open existing"
-             class="form-control"
-             uib-typeahead="config.name for config in state.config.add.list | filter:{name:$viewValue}"
-             typeahead-template-url="blueprint-composer/component/spec-editor/config-item.html"
-             typeahead-editable="true"
-             typeahead-show-hint="true"
-             typeahead-min-length="0"
-             typeahead-select-on-blur="true"
-             typeahead-on-select="onFocusOnConfig($item, $model, $label, $event)"
-             typeahead-no-results="noResults"
-             blur-on-enter />
-
-        <div ng-if="state.config.add.value.length > 0 && noResults" uib-dropdown uib-dropdown-toggle auto-close="disabled" is-open="true">
-            <ul class="dropdown-menu">
-                <!-- mimic real dropdown if nothing found -->
-                <li class="uib-typeahead-match"><a ng-click="addConfigKey()">
-                    <div class="dropdown-item" ng-init="item = match.model">
-                        <div class="dropdown-row">
-                        <span ng-bind-html="state.config.add.value | uibTypeaheadHighlight:query" class="config-name"></span>
-                        <i class="fa fa-fw fa-plus-square-o"></i>
-                    </div>
-                </a></li>
-            </ul>
-        </div>
-    </fieldset>
-
     <div class="spec-configuration config">
         <div class="spec-empty-state" ng-if="filteredItems.length === 0">
           <div ng-if="model.miscData.get('config').length === 0">
@@ -285,8 +253,11 @@
             <h4>No matching configuration</h4>
             <p class="buttons">
                 <button class="btn btn-sm btn-default" ng-if="state.config.search.length > 0" ng-click="state.config.search = ''">Clear search</button>
+                <button class="btn btn-sm btn-default" ng-click="specEditor.addConfigKey(state.config.search)" ng-if="!specEditor.getConfig(state.config.search)">
+                        <i class="fa fa-plus"></i> Add '{{state.config.search}}'
+                </button>
                 <button class="btn btn-sm btn-success" ng-if="!state.config.filter.values.all" ng-click="state.config.filter.values.all = true">
-                    <i class="fa fa-filter"></i> Display all config options
+                    <i class="fa fa-filter"></i> Clear filters
                 </button>
             </p>
           </div>
@@ -508,6 +479,15 @@
                 </div>
             </div>
         </form>
+        
+        <div class="config-add-button" ng-if="filteredItems.length > 0 && state.config.search && !specEditor.getConfig(state.config.search)">
+                <p class="buttons">
+                    <button class="btn btn-sm btn-success" ng-click="specEditor.addConfigKey(state.config.search)">
+                        <i class="fa fa-plus"></i> Add '{{state.config.search}}'
+                    </button>
+                </p>
+        </div>
+        
     </div>
 </br-collapsible>
 

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -174,7 +174,7 @@ export function D3Blueprint(container) {
     };
 
     let viewportWidth = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
-    let zoom = d3.zoom().scaleExtent([0.1, Math.max(1, 1 + log(viewportWidth/1024))]).on('zoom', onSvgZoom);
+    let zoom = d3.zoom().scaleExtent([0.1, Math.max(1, 1 + Math.log(viewportWidth/1024))]).on('zoom', onSvgZoom);
     _svg
         .attr('preserveAspectRatio', 'xMinYMin meet')
         .attr('viewBox', () => {


### PR DESCRIPTION
has a field-based mode and JSON mode

builds on #118 , makes it mergeable

ideally flaws in the PR can be tracked here but addressed in follow-on PRs unless critical.  i'm aware of the following wishlist items:

1. if no params, it's not obvious how to add ("No params" should have option to "Add" one)
2. are the icons in top-right of params section needed (filter etc)
3. if same parameter entered twice you get angular errors
4. parameters section should appear only on application (it's pointless elsewhere)
5. parameters added should show up in the config section (maybe?)
6. do all the fields work as expected when defining a parameter used subsequently (eg label, constraint)
7. parameters are mostly pointless if you're deploying directly, it's mainly for saving and reuse (or some types of export)

i think 1,4,6 need addressed imminently but i don't think they should block merging this