### PR TITLE
Avoiding swagger validation

### DIFF
--- a/ui-modules/rest-api-docs/app/views/main/main.controller.js
+++ b/ui-modules/rest-api-docs/app/views/main/main.controller.js
@@ -56,7 +56,8 @@ export function mainStateController($scope, $log, $cookies) {
         jsonEditor: false,
         defaultModelRendering: 'schema',
         showRequestHeaders: false,
-        showOperationIds: false
+        showOperationIds: false,
+        validatorUrl: null
     });
 
     swaggerUi.load();


### PR DESCRIPTION
In internet isolated environments is impossible reaching the `swagger.json` file, and an error label is shown in the REST API Doc page.
![image](https://user-images.githubusercontent.com/17095501/56495721-88b3f580-64ee-11e9-9484-00212dd3f334.png)

Passing `null` as validator url, the module don't show the validation label as it does when is executed in localhost. 