### PR TITLE
Remove the reserved keyword check for config keys

### DIFF
--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -836,10 +836,6 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             let modelConfig = scope.model.config;
             let result = {};
             for (let [key, value] of modelConfig) {
-                if (blueprintService.isReservedKey(key)) {
-                    $log.warn("skipping reserved word used as config key", key);
-                    continue; // skip
-                }
                 result[key] = getLocalConfigValueFromModelValue(key, value);
             }
             scope.config = result;


### PR DESCRIPTION
 It makes sense to do this for metadata – we don't want to override `brooklyn.enrichers` or `name`. However, there shouldn't be restriction on keys within `brooklyn.config`.

For instance, this change allows the following blueprint:
```yaml
services:
  - type: tomcat-server
    name: Foo
    brooklyn.config:
      cidrBlock: 10.0.0.0/24
      name: myVpc
``` 

whereas previously, `name: myVpc` would have been completely ignored by the composer.