### PR TITLE
Fix UI modules logs

### DIFF
--- a/ui-modules/app-inspector/app/index.js
+++ b/ui-modules/app-inspector/app/index.js
@@ -60,15 +60,18 @@ import {streamState} from "views/main/inspect/activities/detail/stream/stream.co
 import {catalogApiProvider} from "brooklyn-ui-utils/providers/catalog-api.provider";
 import {apiObserverInterceptorProvider} from "brooklyn-ui-utils/providers/api-observer-interceptor.provider";
 
+const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
+
 angular.module('app', [ngResource, ngCookies, ngSanitize, uiRouter, brCore, brUtilsGeneral, brServerStatus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brSensitiveField, brooklynUserManagement, brYamlEditor, brWebNotifications, brExpandablePanel, 'xeditable', apiProvider, entityTree, loadingState, configSensorTable, entityEffector, entityPolicy, breadcrumbNavigation, taskList, taskSunburst, stream, adjunctsList, managementDetail])
     .provider('catalogApi', catalogApiProvider)
     .provider('apiObserverInterceptor', apiObserverInterceptorProvider)
     .filter('specToLabel', specToLabelFilter)
-    .config(['$urlRouterProvider', '$stateProvider', '$logProvider', '$httpProvider', 'apiObserverInterceptorProvider', applicationConfig])
+    .config(['$urlRouterProvider', '$stateProvider', '$logProvider', '$compileProvider', '$httpProvider', 'apiObserverInterceptorProvider', applicationConfig])
     .run(['editableOptions', 'editableThemes', applicationInitialization]);
 
-function applicationConfig($urlRouterProvider, $stateProvider, $logProvider, $httpProvider, apiObserverInterceptorProvider) {
-    $logProvider.debugEnabled(false);
+function applicationConfig($urlRouterProvider, $stateProvider, $logProvider, $compileProvider, $httpProvider, apiObserverInterceptorProvider) {
+    $logProvider.debugEnabled(!IS_PRODUCTION);
+    $compileProvider.debugInfoEnabled(!IS_PRODUCTION);
     $urlRouterProvider
         .otherwise('/');
     $stateProvider

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -71,6 +71,8 @@ import stackViewer from 'angular-java-stack-viewer';
 import {EntityFamily} from "./components/util/model/entity.model";
 import scriptTagDecorator from 'brooklyn-ui-utils/script-tag-non-overwrite/script-tag-non-overwrite';
 
+const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
+
 angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 'ui.router.state.events', brCore,
     brServerStatus, brAutoFocus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement,
     brYamlEditor, brUtils, brSpecEditor, brooklynCatalogSaver, brooklynApi, bottomSheet, stackViewer, brDragndrop,
@@ -79,14 +81,15 @@ angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 
     dslService, paletteDragAndDropService, recentlyUsedService, scriptTagDecorator])
     .provider('composerOverrides', composerOverridesProvider)
     .filter('dslParamLabel', ['$filter', dslParamLabelFilter])
-    .config(['$urlRouterProvider', '$stateProvider', '$logProvider', applicationConfig])
+    .config(['$urlRouterProvider', '$stateProvider', '$logProvider', '$compileProvider', applicationConfig])
     .config(['actionServiceProvider', actionConfig])
     .config(['paletteServiceProvider', paletteConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])
     .run(['$http', httpConfig]);
 
-function applicationConfig($urlRouterProvider, $stateProvider, $logProvider) {
-    $logProvider.debugEnabled(false);
+function applicationConfig($urlRouterProvider, $stateProvider, $logProvider, $compileProvider) {
+    $logProvider.debugEnabled(!IS_PRODUCTION);
+    $compileProvider.debugInfoEnabled(!IS_PRODUCTION);
     $urlRouterProvider
         .otherwise(graphicalState.url);
     $stateProvider

--- a/ui-modules/catalog/app/index.js
+++ b/ui-modules/catalog/app/index.js
@@ -45,7 +45,7 @@ angular.module('app', [ngAnimate, ngCookies, ngResource, brCore, brServerStatus,
 
 
 function applicationConfig($logProvider, $compileProvider) {
-    $logProvider.debugEnabled(IS_PRODUCTION);
+    $logProvider.debugEnabled(!IS_PRODUCTION);
     $compileProvider.debugInfoEnabled(!IS_PRODUCTION);
 }
 

--- a/ui-modules/home/app/index.js
+++ b/ui-modules/home/app/index.js
@@ -35,11 +35,12 @@ import mainDeployState from 'views/main/deploy/deploy.controller';
 import aboutState from 'views/about/about.controller.js';
 
 angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brooklynQuickLaunch, mainState, mainDeployState, aboutState])
-    .config(['$urlRouterProvider', '$logProvider', applicationConfig])
+    .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$http', httpConfig]);
 
-function applicationConfig($urlRouterProvider, $logProvider) {
-    $logProvider.debugEnabled(false);
+function applicationConfig($urlRouterProvider, $logProvider, $compileProvider) {
+    $logProvider.debugEnabled(!IS_PRODUCTION);
+    $compileProvider.debugInfoEnabled(!IS_PRODUCTION);
     $urlRouterProvider.otherwise('/');
 }
 

--- a/ui-modules/location-manager/app/index.js
+++ b/ui-modules/location-manager/app/index.js
@@ -38,13 +38,16 @@ import wizardAdvancedState from 'views/wizard/advanced/advanced.controller';
 import wizardByonState from 'views/wizard/byon/byon.controller';
 import wizardCloudState from 'views/wizard/cloud/cloud.controller';
 
+const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
+
 angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brAutoFocus, brInterstitialSpinner, brooklynModuleLinks, brSensitiveField, brooklynUserManagement, brooklynApi, locationsState, detailState, wizardState, wizardAdvancedState, wizardByonState, wizardCloudState])
-    .config(['$urlRouterProvider', '$logProvider', applicationConfig])
+    .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])
     .run(['$http', httpConfig]);
 
-function applicationConfig($urlRouterProvider, $logProvider) {
-    $logProvider.debugEnabled(false);
+function applicationConfig($urlRouterProvider, $logProvider, $compileProvider) {
+    $logProvider.debugEnabled(!IS_PRODUCTION);
+    $compileProvider.debugInfoEnabled(!IS_PRODUCTION);
     $urlRouterProvider.otherwise('/');
 }
 

--- a/ui-modules/logout/app/index.js
+++ b/ui-modules/logout/app/index.js
@@ -30,12 +30,15 @@ import brServerStatus from 'brooklyn-ui-utils/server-status/server-status';
 
 import mainState from './views/main/main.controller';
 
+const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
+
 angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brInterstitialSpinner, brServerStatus, brooklynModuleLinks, brooklynUserManagement, mainState])
-    .config(['$urlRouterProvider', '$logProvider', applicationConfig])
+    .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$http', httpConfig]);
 
-function applicationConfig($urlRouterProvider, $logProvider) {
-    $logProvider.debugEnabled(false);
+function applicationConfig($urlRouterProvider, $logProvider, $compileProvider) {
+    $logProvider.debugEnabled(!IS_PRODUCTION);
+    $compileProvider.debugInfoEnabled(!IS_PRODUCTION);
     $urlRouterProvider.otherwise('/');
 }
 

--- a/ui-modules/shared/config/build/webpack.config.js
+++ b/ui-modules/shared/config/build/webpack.config.js
@@ -224,7 +224,6 @@ if (ENV === 'development') {
             mangle: false,
             compress: {
                 dead_code: true,
-                drop_console: true,
                 unused: true,
                 warnings: false
             }


### PR DESCRIPTION
This does the following:
- enable debug logs for non-production builds
- enable angular runtime logs for non-production builds
- remove the `drop_console` option from webpack to display info, warn and error logs on production builds