### PR TITLE
add an "Open in Composer" button to quick launch

### DIFF
--- a/ui-modules/home/app/views/main/deploy/deploy.controller.js
+++ b/ui-modules/home/app/views/main/deploy/deploy.controller.js
@@ -81,7 +81,8 @@ export function deployStateController($scope, $state, $stateParams, $uibModal, b
     function modalController($scope, $location, entitySpec, locations) {
         $scope.app = entitySpec;
         $scope.locations = locations;
-        $scope.args = $location.search();
+        // can optionally add: { noEditButton: true, noComposerButton: true }, or pass in URL
+        $scope.args = angular.extend({}, $location.search());
     }
 }
 

--- a/ui-modules/home/app/views/main/main.controller.js
+++ b/ui-modules/home/app/views/main/main.controller.js
@@ -42,6 +42,13 @@ export const mainState = {
         }],
         catalogApps: ['catalogApi', (catalogApi) => {
             return catalogApi.getTypes({params: {supertype: 'org.apache.brooklyn.api.entity.Application'}}).then(applications => {
+                // optionally tag things with 'catalog_quick_launch': if any apps are so tagged, 
+                // then only apps with such tags will be shown;
+                // in all cases only show those marked as templates
+                var appsWithTag = applications.filter(application => application.tags && application.tags.indexOf("catalog_quick_launch")>=0);
+                if (appsWithTag.length) {
+                    applications = appsWithTag;
+                }
                 return applications.filter(application => application.template);
             });
         }]

--- a/ui-modules/utils/quick-launch/quick-launch.html
+++ b/ui-modules/utils/quick-launch/quick-launch.html
@@ -136,7 +136,8 @@
 
 <div class="quick-launch-actions">
     <button class="btn btn-lg btn-default" ng-if="yamlViewDisplayed && appHasWizard" ng-disabled="deploying" ng-click="hideEditor()">Back</button>
-    <button class="btn btn-lg btn-default" ng-if="!yamlViewDisplayed" ng-disabled="deploying" ng-click="showEditor()">Open in Editor</button>
+    <button class="btn btn-lg btn-default" ng-if="!yamlViewDisplayed && !args.noEditButton" ng-disabled="deploying" ng-click="showEditor()">YAML</button>
+    <button class="btn btn-lg btn-default" ng-if="!args.noComposerButton" ng-disabled="deploying" ng-click="openComposer()">Open in Composer</button>
     <button class="btn btn-lg btn-success pull-right" ng-disabled="(deploy.$invalid || deploying) && !yamlViewDisplayed" ng-click="deployApp()">{{deploying ? 'Deploying&hellip;' : 'Deploy'}}</button>
 </div>
 

--- a/ui-modules/utils/quick-launch/quick-launch.js
+++ b/ui-modules/utils/quick-launch/quick-launch.js
@@ -39,17 +39,18 @@ export function quickLaunchDirective() {
             app: '=',
             locations: '=',
             args: '=?',
-            callback: '=?'
+            callback: '=?',
         },
-        controller: ['$scope', '$http', 'brSnackbar', controller]
+        controller: ['$scope', '$http', '$location', 'brSnackbar', controller]
     };
 
-    function controller($scope, $http, brSnackbar) {
+    function controller($scope, $http, $location, brSnackbar) {
         $scope.deploying = false;
         $scope.model = {
             newConfigFormOpen: false
         };
-        if ($scope.args && $scope.args.location) {
+        $scope.args = $scope.args || {};
+        if ($scope.args.location) {
             $scope.model.location = $scope.args.location;
         }
         $scope.toggleNewConfigForm = toggleNewConfigForm;
@@ -57,6 +58,7 @@ export function quickLaunchDirective() {
         $scope.deleteConfigField = deleteConfigField;
         $scope.deployApp = deployApp;
         $scope.showEditor = showEditor;
+        $scope.openComposer = openComposer;
         $scope.hideEditor = hideEditor;
         $scope.clearError = clearError;
 
@@ -169,6 +171,19 @@ export function quickLaunchDirective() {
             return yaml.safeDump(newApp);
         }
 
+        function buildComposerYaml() {
+            let newApp = {
+                name: $scope.model.name || $scope.app.displayName,
+            };
+            if ($scope.model.location) {
+                newApp.location = $scope.model.location;
+            }
+            if ($scope.entityToDeploy[BROOKLYN_CONFIG]) {
+                newApp[BROOKLYN_CONFIG] = $scope.entityToDeploy[BROOKLYN_CONFIG]
+            }
+            return yaml.safeDump(newApp) + "\n" + $scope.app.plan.data;
+        }
+
         function showEditor() {
             $scope.editorYaml = buildYaml();
             $scope.yamlViewDisplayed = true;
@@ -176,6 +191,11 @@ export function quickLaunchDirective() {
 
         function hideEditor() {
             $scope.yamlViewDisplayed = false;
+        }
+
+        function openComposer() {
+            window.location.href = '/brooklyn-ui-blueprint-composer/#!/graphical?'+
+                'yaml='+encodeURIComponent(buildComposerYaml());
         }
 
         function clearError() {

--- a/ui-modules/utils/quick-launch/quick-launch.less
+++ b/ui-modules/utils/quick-launch/quick-launch.less
@@ -97,6 +97,7 @@ brooklyn-quick-launch {
 
   .quick-launch-actions {
     border-top: 1px solid @gray-lighter;
+    min-height: 90px;  // needed if only floating buttons are shown (eg pull-right success)
   }
 }
 


### PR DESCRIPTION
the effect is to open the template's definition in composer

viz, clicking one of the quick-launch templates show

![image](https://user-images.githubusercontent.com/496540/69051296-d00a5200-09fb-11ea-808e-86a70dc124f2.png)

`YAML` opens the in-modal editor (as before), but the new `Open in Composer` takes you to:

![image](https://user-images.githubusercontent.com/496540/69051367-ff20c380-09fb-11ea-9579-b4eb93f49e40.png)

the location and config are as selected in quick launch, with the full original template