### PR TITLE
corrects pagination issue

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -97,7 +97,6 @@ export function catalogSelectorDirective() {
 
         $scope.viewModes = PALETTE_VIEW_MODES;
         $scope.viewOrders = PALETTE_VIEW_ORDERS;
-
         if (!$scope.state) $scope.state = {};
         if (!$scope.state.viewMode) $scope.state.viewMode = PALETTE_VIEW_MODES.normal;
 
@@ -350,9 +349,10 @@ export function catalogSelectorDirective() {
                 // no main, or hidden, or items per page fixed
                 return;
             }
-            let header = angular.element(main[0].querySelector(".catalog-palette-header"));
-            let footer = angular.element(main[0].querySelector(".catalog-palette-footer"));
-            rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor((main[0].offsetHeight - header[0].offsetHeight - footer[0].offsetHeight - 16) / ($scope.state.viewMode.rowHeightPx || 96)));
+            let palette = angular.element(document.getElementsByClassName("palette-and-or-toolbar"));
+            let header = angular.element($element[0].querySelector(".catalog-palette-header"));
+            let footer = angular.element($element[0].querySelector(".catalog-palette-footer"));
+            rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor((palette[0].offsetHeight - (header[0].offsetHeight + footer[0].offsetHeight + 16)) / ($scope.state.viewMode.rowHeightPx || 96)));
         }
         $scope.$apply(() => $scope.pagination.itemsPerPage = rowsPerPage * $scope.state.viewMode.itemsPerRow);
     }

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -345,7 +345,7 @@ export function catalogSelectorDirective() {
         let rowsPerPage = $scope.rowsPerPage;
         if (!rowsPerPage) {
             let palette = angular.element(document.querySelector(".page-main-area"));
-            let toolbar = angular.element(document.querySelector(".navbar"));
+            let toolbar = angular.element(document.querySelector(".navbar-default"));
             let header = angular.element($element[0].querySelector(".catalog-palette-header"));
             let footer = angular.element($element[0].querySelector(".catalog-palette-footer"));
             rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor((palette[0].offsetHeight - (toolbar[0].offsetHeight + header[0].offsetHeight + footer[0].offsetHeight + 16)) / ($scope.state.viewMode.rowHeightPx || 96)));

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -345,7 +345,7 @@ export function catalogSelectorDirective() {
         let rowsPerPage = $scope.rowsPerPage;
         if (!rowsPerPage) {
             let palette = angular.element(document.querySelector(".page-main-area"));
-            let toolbar = angular.element(document.querySelector(".navbar-default"));
+            let toolbar = angular.element(document.querySelector(".navbar-mode"));
             let header = angular.element($element[0].querySelector(".catalog-palette-header"));
             let footer = angular.element($element[0].querySelector(".catalog-palette-footer"));
             rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor((palette[0].offsetHeight - (toolbar[0].offsetHeight + header[0].offsetHeight + footer[0].offsetHeight + 16)) / ($scope.state.viewMode.rowHeightPx || 96)));

--- a/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-selector/catalog-selector.directive.js
@@ -344,15 +344,11 @@ export function catalogSelectorDirective() {
     function repaginate($scope, $element) {
         let rowsPerPage = $scope.rowsPerPage;
         if (!rowsPerPage) {
-            let main = angular.element($element[0].querySelector(".catalog-palette-main"));
-            if (!main || main[0].offsetHeight == 0) {
-                // no main, or hidden, or items per page fixed
-                return;
-            }
-            let palette = angular.element(document.getElementsByClassName("palette-and-or-toolbar"));
+            let palette = angular.element(document.querySelector(".page-main-area"));
+            let toolbar = angular.element(document.querySelector(".navbar"));
             let header = angular.element($element[0].querySelector(".catalog-palette-header"));
             let footer = angular.element($element[0].querySelector(".catalog-palette-footer"));
-            rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor((palette[0].offsetHeight - (header[0].offsetHeight + footer[0].offsetHeight + 16)) / ($scope.state.viewMode.rowHeightPx || 96)));
+            rowsPerPage = Math.max(MIN_ROWS_PER_PAGE, Math.floor((palette[0].offsetHeight - (toolbar[0].offsetHeight + header[0].offsetHeight + footer[0].offsetHeight + 16)) / ($scope.state.viewMode.rowHeightPx || 96)));
         }
         $scope.$apply(() => $scope.pagination.itemsPerPage = rowsPerPage * $scope.state.viewMode.itemsPerRow);
     }


### PR DESCRIPTION
When switching between pagination mode the number of displayed items was never reduced, because rowsPerPage was calculated based on the height of the scrolling view. Changed to be calculated based on the height of the non-scrolling container instead. List and compact list are now paginated where previously all items were displayed.
https://issues.apache.org/jira/browse/BROOKLYN-619