### PR TITLE
add time information to application data to allow ordering launch time

### DIFF
--- a/ui-modules/app-inspector/app/components/entity-tree/entity-tree.directive.js
+++ b/ui-modules/app-inspector/app/components/entity-tree/entity-tree.directive.js
@@ -57,14 +57,8 @@ export function entityTreeDirective() {
 
         let observers = [];
 
-        let timeData = [];
-
         applicationApi.applicationsTree().then((response)=> {
             vm.applications = response.data;
-            vm.applications.forEach(app => {
-                getTimeData(app);
-            });
-
 
             observers.push(response.subscribe((response)=> {
                 response.data
@@ -84,17 +78,7 @@ export function entityTreeDirective() {
                         });
                     });
 
-                //Unless an app has just been loaded the start time information will be held locally in 'timeData'
-                vm.applications = response.data.map(app => {
-                    const appStartData = timeData.find( item => item.applicationId === app.applicationId);
-                    if (!appStartData) {
-                        getTimeData (app)
-                    }
-                    return {
-                        ...app,
-                        startTimeUtc: appStartData ? appStartData.startTimeUtc : Date.now()
-                    }
-                });
+                vm.applications = response.data;
 
                 function spawnNotification(app, opts) {
                     iconService.get(app).then((icon)=> {
@@ -106,24 +90,6 @@ export function entityTreeDirective() {
                     });
                 }
             }));
-            
-        //retrieves start time of the app from the entity api.
-        function getTimeData(app) {
-            //remove entries from timeData relating to apps that have been undeployed
-            timeData = timeData.filter(item => vm.applications.find(app => app.applicationId === item.applicationId))
-            entityApi.entityActivities(app.applicationId, app.applicationId).then( response => {
-                if ((response.data.length === 0) || (timeData.find(item => item.applicationId === app.applicationId))) {
-                    return;
-                };
-                timeData.push({
-                    applicationId: app.applicationId,
-                    startTimeUtc: response.data[0].startTimeUtc
-                });
-                app.startTimeUtc = response.data[0].startTimeUtc
-            }).catch((error) => {
-                console.log(error);
-            });
-            }
         });
 
         $scope.$on('$destroy', ()=> {

--- a/ui-modules/app-inspector/app/components/entity-tree/entity-tree.directive.js
+++ b/ui-modules/app-inspector/app/components/entity-tree/entity-tree.directive.js
@@ -43,6 +43,9 @@ export function entityTreeDirective() {
     return {
         restrict: 'E',
         template: entityTreeTemplate,
+        scope: {
+           sortReverse: '=',
+        },
         controller: ['$scope', '$state', 'applicationApi', 'entityApi', 'iconService', 'brWebNotifications', controller],
         controllerAs: 'vm'
     };

--- a/ui-modules/app-inspector/app/components/entity-tree/entity-tree.html
+++ b/ui-modules/app-inspector/app/components/entity-tree/entity-tree.html
@@ -16,7 +16,7 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<entity-node ng-repeat="application in vm.applications | orderBy: sortReverse? '-startTimeUtc': 'startTimeUtc' track by application.id" entity="application" application-id="application.id"></entity-node>
+<entity-node ng-repeat="application in vm.applications | orderBy: sortReverse? '-creationTimeUtc': 'creationTimeUtc' track by application.id" entity="application" application-id="application.id"></entity-node>
 <p class="expand-tree-message text-center" ng-if="vm.applications.length > 0"><small><kbd>shift</kbd> + <kbd>{{navigator.appVersion.indexOf("Mac") !== -1 ? '⌘' : '⊞'}}</kbd> + click to expand all children</small></p>
 <div class="empty-tree text-muted text-center" ng-if="vm.applications.length === 0">
     <hr />

--- a/ui-modules/app-inspector/app/components/entity-tree/entity-tree.html
+++ b/ui-modules/app-inspector/app/components/entity-tree/entity-tree.html
@@ -16,7 +16,7 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<entity-node ng-repeat="application in vm.applications | orderBy: '-startTimeUtc' track by application.id" entity="application" application-id="application.id"></entity-node>
+<entity-node ng-repeat="application in vm.applications | orderBy: sortReverse? '-startTimeUtc': 'startTimeUtc' track by application.id" entity="application" application-id="application.id"></entity-node>
 <p class="expand-tree-message text-center" ng-if="vm.applications.length > 0"><small><kbd>shift</kbd> + <kbd>{{navigator.appVersion.indexOf("Mac") !== -1 ? '⌘' : '⊞'}}</kbd> + click to expand all children</small></p>
 <div class="empty-tree text-muted text-center" ng-if="vm.applications.length === 0">
     <hr />

--- a/ui-modules/app-inspector/app/components/entity-tree/entity-tree.html
+++ b/ui-modules/app-inspector/app/components/entity-tree/entity-tree.html
@@ -16,7 +16,7 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<entity-node ng-repeat="application in vm.applications track by application.id" entity="application" application-id="application.id"></entity-node>
+<entity-node ng-repeat="application in vm.applications | orderBy: '-startTimeUtc' track by application.id" entity="application" application-id="application.id"></entity-node>
 <p class="expand-tree-message text-center" ng-if="vm.applications.length > 0"><small><kbd>shift</kbd> + <kbd>{{navigator.appVersion.indexOf("Mac") !== -1 ? '⌘' : '⊞'}}</kbd> + click to expand all children</small></p>
 <div class="empty-tree text-muted text-center" ng-if="vm.applications.length === 0">
     <hr />

--- a/ui-modules/app-inspector/app/views/main/main.controller.js
+++ b/ui-modules/app-inspector/app/views/main/main.controller.js
@@ -27,11 +27,16 @@ export const mainState = {
     controllerAs: 'ctrl'
 };
 
+const savedSortReverse = 'app-inspector-sort-reverse';
+
 export function mainController($scope, $q, brWebNotifications) {
     $scope.$emit(HIDE_INTERSTITIAL_SPINNER_EVENT);
 
     let ctrl = this;
 
+    ctrl.sortReverse = localStorage && localStorage.getItem(savedSortReverse) !== null ?
+        JSON.parse(localStorage.getItem(savedSortReverse)) :
+        true;
     brWebNotifications.supported.then(() => {
         ctrl.isNotificationsSupported = true;
     }).catch(() => {
@@ -47,6 +52,17 @@ export function mainController($scope, $q, brWebNotifications) {
     brWebNotifications.getPermission().then(permission => {
         ctrl.isNotificationsBlocked = permission === 'denied';
     });
+
+    ctrl.toggleSortOrder = () => {
+        ctrl.sortReverse = !ctrl.sortReverse;
+        if (localStorage) {
+            try {
+                localStorage.setItem(savedSortReverse, JSON.stringify(ctrl.sortReverse));
+            } catch (ex) {
+                $log.error('Cannot save app sort preferences: ' + ex.message);
+            }
+        }
+    }
 
     ctrl.toggleNotifications = () => {
         brWebNotifications.isEnabled().then(() => {

--- a/ui-modules/app-inspector/app/views/main/main.less
+++ b/ui-modules/app-inspector/app/views/main/main.less
@@ -20,11 +20,9 @@
 
   .entity-tree-header {
     display: flex;
+    justify-content: space-between;
 
-    .entity-tree-title {
-      flex-grow: 1;
-    }
-    .entity-tree-action {
+    .entity-tree-title, .entity-tree-sort-action, .entity-tree-action {
       flex-shrink: 1;
       vertical-align: middle;
       margin-left: 0.5em;

--- a/ui-modules/app-inspector/app/views/main/main.template.html
+++ b/ui-modules/app-inspector/app/views/main/main.template.html
@@ -22,31 +22,33 @@
             <br-card>
                 <br-card-content class="entity-tree">
                     <div class="entity-tree-header">
-                        <h2 class="entity-tree-title">Applications</h2>
-
-                        <button class="entity-sort-action" >
-                            <div class="entity-sort-action-toggle" ng-click="ctrl.toggleSortOrder($event)" >
-                                <span class="glyphicon" ng-class="ctrl.sortReverse ? 'fa fa-sort-amount-desc' : 'fa fa-sort-amount-asc'"></span>
-                            </div>
-                        </button>
-                        <button class="btn btn-link entity-tree-action"
+                        <div class="entity-tree-header-section">
+                            <h2 class="entity-tree-title">Applications</h2>
+                            <button class="btn btn-sm btn-default entity-tree-sort-action" ng-click="ctrl.toggleSortOrder($event)">
+                                <div>
+                                    <span class="glyphicon" ng-class="ctrl.sortReverse ? 'fa fa-sort-amount-desc' : 'fa fa-sort-amount-asc'"></span>
+                                </div>
+                            </button>
+                        </div>
+                        <div class="entity-tree-header-section">
+                            <button class="btn btn-link entity-tree-action"
                                 ng-class="{'btn-sm': !ctrl.isNotificationsBlocked, 'btn-xs': ctrl.isNotificationsBlocked}"
                                 ng-if="ctrl.isNotificationsSupported"
                                 ng-disabled="ctrl.isNotificationsBlocked"
                                 ng-click="ctrl.toggleNotifications()">
-                            <i class="fa fa-bell notifications" ng-if="!ctrl.isNotificationsBlocked"
-                                ng-class="{'active': ctrl.isNotificationsEnabled}"></i>
-                            <span class="fa-stack" ng-if="ctrl.isNotificationsBlocked"
-                                  uib-tooltip="Notifications are currently blocked. You can allow them in your browser settings"
-                                  tooltip-placement="left">
-                                <i class="fa fa-bell fa-stack-1x"></i>
-                                <i class="fa fa-ban fa-stack-2x text-danger"></i>
-                            </span>
-                        </button>
-
-                        <a href="/brooklyn-ui-blueprint-composer" class="btn btn-sm btn-default entity-tree-action">
-                            <i class="fa fa-plus"></i>
-                        </a>
+                                <i class="fa fa-bell notifications" ng-if="!ctrl.isNotificationsBlocked"
+                                   ng-class="{'active': ctrl.isNotificationsEnabled}"></i>
+                                <span class="fa-stack" ng-if="ctrl.isNotificationsBlocked"
+                                      uib-tooltip="Notifications are currently blocked. You can allow them in your browser settings"
+                                      tooltip-placement="left">
+                                    <i class="fa fa-bell fa-stack-1x"></i>
+                                    <i class="fa fa-ban fa-stack-2x text-danger"></i>
+                                </span>
+                            </button>
+                            <a href="/brooklyn-ui-blueprint-composer" class="btn btn-sm btn-default entity-tree-action">
+                                <i class="fa fa-plus"></i>
+                            </a>
+                        </div>
                     </div>
 
                     <entity-tree sort-reverse="ctrl.sortReverse"></entity-tree>

--- a/ui-modules/app-inspector/app/views/main/main.template.html
+++ b/ui-modules/app-inspector/app/views/main/main.template.html
@@ -24,6 +24,11 @@
                     <div class="entity-tree-header">
                         <h2 class="entity-tree-title">Applications</h2>
 
+                        <button class="entity-sort-action" >
+                            <div class="entity-sort-action-toggle" ng-click="ctrl.toggleSortOrder($event)" >
+                                <span class="glyphicon" ng-class="ctrl.sortReverse ? 'fa fa-sort-amount-desc' : 'fa fa-sort-amount-asc'"></span>
+                            </div>
+                        </button>
                         <button class="btn btn-link entity-tree-action"
                                 ng-class="{'btn-sm': !ctrl.isNotificationsBlocked, 'btn-xs': ctrl.isNotificationsBlocked}"
                                 ng-if="ctrl.isNotificationsSupported"
@@ -44,7 +49,7 @@
                         </a>
                     </div>
 
-                    <entity-tree></entity-tree>
+                    <entity-tree sort-reverse="ctrl.sortReverse"></entity-tree>
                 </br-card-content>
             </br-card>
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BROOKLYN-620
Data retrieved from the application api does not contain any time information. 
To allow ordering by time we have to make a further call to entityApi.entityActivities. This returns an array of all activities. We take the startTimeUtc value of the first entry as the application start.

However...

The application data is updated frequently and this erases the time information. To avoid having to make multiple api calls (which causes an annoying flicker on the screen) we store the time information locally in an array of objects. For existing applications we can simply merge this time information with the refreshed data. For new applications, we temporarily set the startTimeUtc to the current time to ensure it's at the top of the list and then call a method to update our local time data.

<img width="524" alt="Screenshot 2019-12-12 at 18 31 16" src="https://user-images.githubusercontent.com/21359664/70738932-a6e49500-1d0d-11ea-9739-fd05191e235a.png">

Also saves sort order preference which resolves 
https://issues.apache.org/jira/browse/BROOKLYN-622 