### PR TITLE
Fix composer open

### DIFF
--- a/ui-modules/blueprint-composer/app/views/main/main.controller.js
+++ b/ui-modules/blueprint-composer/app/views/main/main.controller.js
@@ -131,9 +131,28 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
         
         yaml = edit.type.plan.data;
     }
+    
+    vm.isGraphicalMode = () => {
+        return $state.includes(graphicalState.name);
+    };
+    vm.isYamlMode = () => {
+        return $state.includes(yamlState.name);
+    };
 
     if (yaml) {
-        blueprintService.setFromYaml(yaml);
+        if (vm.isYamlMode()) {
+            // don't set blueprint; yaml mode will take from "initial yaml" 
+            blueprintService.reset();
+            $scope.initialYaml = yaml;
+        } else {
+            try {
+                blueprintService.setFromYaml(yaml);
+            } catch (e) {
+                console.warn("YAML supplied for editing is not valid for a blueprint. It will be ignored unless opened in the YAML editor:", e);
+                blueprintService.reset();
+                $scope.initialYaml = yaml;
+            }
+        }
     } else {
         blueprintService.reset();
     }
@@ -145,10 +164,6 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
         }
 
         deployApplication();
-    };
-
-    vm.isGraphicalMode = () => {
-        return $state.includes(graphicalState.name);
     };
 
     vm.getAllActions = () => {

--- a/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
@@ -39,6 +39,11 @@ function yamlStateController($scope, $rootScope, $timeout, blueprintService, brS
         brSnackbar.create(`Cannot load blueprint: ${ex.message}`);
         vm.yaml = '';
     }
+    if ($scope.initialYaml && !vm.yaml) {
+        // either yaml was supplied and yaml mode requested, skipping blueprint setup,
+        // or the yaml was invalid, an error logged, and this was recorded
+        vm.yaml = $scope.initialYaml; 
+    }
 
     if (!CodeMirror.lint.hasOwnProperty('yaml-composer')) {
         CodeMirror.registerGlobalHelper('lint', 'yaml-composer', mode => mode.name === 'yaml', (text, options, cm) => {


### PR DESCRIPTION
In a lot of edge cases, the "Open in Composer" button from quick launch generated errors.
This fixes many of the errors, and in cases where there are errors the composer responds sensibly (logging warning, and if yaml mode requested, preserving the input yaml).