### PR TITLE
add custom onChange directive to correct file uploader bug

### DIFF
--- a/ui-modules/utils/catalog-uploader/catalog-uploader.html
+++ b/ui-modules/utils/catalog-uploader/catalog-uploader.html
@@ -23,7 +23,7 @@
             <div class="col-sm-12 text-center">
                 <p><i class="fa fa-3x fa-upload"></i></p>
                 <p>
-                    <input type="file" name="files" id="files" multiple onchange="angular.element(this).scope().filesChanged(this)" />
+                    <input type="file" name="files" id="files" multiple custom-on-change="filesChanged" />
                     <label for="files" ng-click="choose()"><strong>Choose files</strong><span class="drag-upload"> or drag & drop them here</span>.</label>
                 </p>
             </div>

--- a/ui-modules/utils/catalog-uploader/catalog-uploader.js
+++ b/ui-modules/utils/catalog-uploader/catalog-uploader.js
@@ -223,8 +223,6 @@ export function customOnChangeDirective() {
             element.on('$destroy', function() {
                 element.off();
             });
-
-
         }
     };
 }


### PR DESCRIPTION
Corrects a bug where uploading a file to the catalog via the file picker did not work.
https://issues.apache.org/jira/browse/BROOKLYN-624

Resolves an issue with the getCatalogItemUrl method, which checks for the existence of a string 'org.apache.brooklyn.api.location.Location' in item.supertypes to determine the format of the url:

- Adds a check for the existence of the property supertypes before calling 'includes' on it.
- Checks for the string in item.tags if the supertypes property is not present.
