### PR TITLE
minor cleanups with version + NPE

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -700,7 +700,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService)
         });
 
         relationships = Array.from(entity.config.values())
-            .filter(config => config[DSL_ENTITY_SPEC] && config[DSL_ENTITY_SPEC] instanceof Entity)
+            .filter(config => config && config[DSL_ENTITY_SPEC] && config[DSL_ENTITY_SPEC] instanceof Entity)
             .map(config => config[DSL_ENTITY_SPEC])
             .reduce((relationships, spec) => {
             return relationships.concat(getRelationships(spec));

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -91,6 +91,9 @@ spec-editor {
     .entity-type-header {
       font-size: 105%;
       margin-right: 1em;
+      // allow this to wrap, as it's important to be able to read it;
+      // break anywhere in case it's of the form my.type.HasGotAVeryVeryVeryLongName
+      word-break: break-all;
     }
     .label.version {
       vertical-align: 2px;

--- a/ui-modules/utils/quick-launch/quick-launch.js
+++ b/ui-modules/utils/quick-launch/quick-launch.js
@@ -74,7 +74,7 @@ export function quickLaunchDirective() {
             $scope.appHasWizard = parsedPlan!=null && !checkForLocationTags(parsedPlan);
             $scope.yamlViewDisplayed = !$scope.appHasWizard;
             $scope.entityToDeploy = {
-                type: $scope.app.symbolicName
+                type: $scope.app.symbolicName + ($scope.app.version ? ':' + $scope.app.version : ''),
             };
             if ($scope.app.config) {
                 $scope.configMap = $scope.app.config.reduce((result, config) => {


### PR DESCRIPTION
- if using quick launcher or catalog "deploy", it ignored the version; now it respects the version
- in composer, it could break if a config value was null, now it guards against that
- in composer, name wrapping was only permitted for words, which meant `type.name.xxxxxx` wouldn't wrap; now it can wrap anywhere