### PR TITLE
Update frontend-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <maven-war-plugin.version>3.0.0</maven-war-plugin.version>
-        <frontend-maven-plugin.version>1.3</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.8.0</frontend-maven-plugin.version>
         <pax-web.version>7.2.3</pax-web.version>
         <pax-web-extender-whiteboard.version>${pax-web.version}</pax-web-extender-whiteboard.version>
 


### PR DESCRIPTION
Version 1.3 was causing NPE under some environments, especially when using the `make-release-artifacts.sh` script. The latest version fixes this issue + a couple of others.