### PR TITLE
add relativePath to parent for release make

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
         <groupId>org.apache.brooklyn</groupId>
         <artifactId>brooklyn-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
-        <!-- do not link to sibling directory as that breaks builds where this code is embedded, e.g. for branding;
-             we require that brooklyn-server is built first (this is needed anyway for the modularity java code) -->
+        <relativePath>../brooklyn-server/parent/</relativePath>
     </parent>
 
     <groupId>org.apache.brooklyn.ui</groupId>


### PR DESCRIPTION
This adds back the `relativePath` to the parent in the pom, to allow the `make_release_artifacts.sh` to work. This is required to get https://github.com/apache/brooklyn-dist/pull/150 to work.

Without this commit the script breaks like below (abbreviated):

```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.apache.brooklyn.ui:brooklyn-ui-parent:${revision}: Could not find artifact org.apache.brooklyn:brooklyn-parent:pom:1.0.0 in ...) and 'parent.relativePath' points at wrong local POM @ line 24, column 13
````

@ahgittin this undoes the change https://github.com/apache/brooklyn-ui/commit/f6b88085815bb044c782db1344a5536c8730d01f and probably therefore undoes the fix for embedded builds. What do you think of this? Could we merge this and figure out some other fix for those?



