### PR TITLE
Fixing an issue when building brooklyn-ui for downstream projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <maven-war-plugin.version>3.0.0</maven-war-plugin.version>
-        <frontend-maven-plugin.version>1.8.0</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.9.0</frontend-maven-plugin.version>
         <pax-web.version>7.2.3</pax-web.version>
         <pax-web-extender-whiteboard.version>${pax-web.version}</pax-web-extender-whiteboard.version>
 


### PR DESCRIPTION
The issue was fixed in version 1.9.0 of the plugin, see: https://github.com/eirslett/frontend-maven-plugin/issues/820#issuecomment-570634363