### PR TITLE
auto-set a name for the app in quick-launch, and

### DIFF
--- a/ui-modules/home/app/views/main/deploy/deploy.controller.js
+++ b/ui-modules/home/app/views/main/deploy/deploy.controller.js
@@ -22,6 +22,7 @@ import uiRouter from 'angular-ui-router';
 import brooklynApi from 'brooklyn-ui-utils/brooklyn.api/brooklyn.api';
 import {HIDE_INTERSTITIAL_SPINNER_EVENT} from 'brooklyn-ui-utils/interstitial-spinner/interstitial-spinner';
 import modalTemplate from './modal.template.html';
+import {filterCatalogQuickLaunch} from '../main.controller.js';
 
 const MODULE_NAME = 'states.main.deploy';
 
@@ -54,9 +55,7 @@ export function deployStateController($scope, $state, $stateParams, $uibModal, b
             entitySpec: ['catalogApi', (catalogApi) => {
                 return catalogApi.getBundleType($stateParams.bundleSymbolicName, $stateParams.bundleVersion, $stateParams.typeSymbolicName, $stateParams.typeVersion);
             }],
-            locations: ['locationApi', (locationApi) => {
-                return locationApi.getLocations();
-            }]
+            locations: ['locationApi', locationApi => locationApi.getLocations()],
         }
     });
 
@@ -80,9 +79,17 @@ export function deployStateController($scope, $state, $stateParams, $uibModal, b
 
     function modalController($scope, $location, entitySpec, locations) {
         $scope.app = entitySpec;
-        $scope.locations = locations;
-        // can optionally add: { noEditButton: true, noComposerButton: true }, or pass in URL
-        $scope.args = angular.extend({}, $location.search());
+        $scope.locations = filterCatalogQuickLaunch(locations, (t) => {
+                $scope.usingCatalogQuickLaunchTags = t.length > 0;
+            });
+        
+        // also supports { noEditButton: true, noComposerButton: true }
+        // see quick-launch.js for more info
+        $scope.args = angular.extend({
+                noCreateLocationLink: $scope.usingCatalogQuickLaunchTags
+            },
+            $location.search());
+        
     }
 }
 

--- a/ui-modules/home/app/views/main/deploy/deploy.controller.js
+++ b/ui-modules/home/app/views/main/deploy/deploy.controller.js
@@ -22,7 +22,7 @@ import uiRouter from 'angular-ui-router';
 import brooklynApi from 'brooklyn-ui-utils/brooklyn.api/brooklyn.api';
 import {HIDE_INTERSTITIAL_SPINNER_EVENT} from 'brooklyn-ui-utils/interstitial-spinner/interstitial-spinner';
 import modalTemplate from './modal.template.html';
-import {filterCatalogQuickLaunch} from '../main.controller.js';
+import {filterCatalogQuickLaunch} from '../main.controller.js';  // this really should be handled by angular DI 
 
 const MODULE_NAME = 'states.main.deploy';
 
@@ -80,13 +80,16 @@ export function deployStateController($scope, $state, $stateParams, $uibModal, b
     function modalController($scope, $location, entitySpec, locations) {
         $scope.app = entitySpec;
         $scope.locations = filterCatalogQuickLaunch(locations, (t) => {
-                $scope.usingCatalogQuickLaunchTags = t.length > 0;
+                $scope.usingLocationCatalogQuickLaunchTags = t.length > 0;
             });
         
         // also supports { noEditButton: true, noComposerButton: true }
         // see quick-launch.js for more info
         $scope.args = angular.extend({
-                noCreateLocationLink: $scope.usingCatalogQuickLaunchTags
+                // disable "create location" is admin has configured locations with tags.
+                // called out in docs in https://github.com/apache/brooklyn-docs/pull/299.
+                // a better approach would be to add config on the server to configure this.
+                noCreateLocationLink: $scope.usingLocationCatalogQuickLaunchTags
             },
             $location.search());
         

--- a/ui-modules/home/app/views/main/deploy/modal.template.html
+++ b/ui-modules/home/app/views/main/deploy/modal.template.html
@@ -17,4 +17,4 @@
   under the License.
 -->
 <br-svg type="close" class="modal-close pull-right" ng-click="$dismiss('Dismiss deployment modal')"></br-svg>
-<brooklyn-quick-launch app="app" args="args" locations="locations" callback="$close"></brooklyn-quick-launch>
+<brooklyn-quick-launch app="app" args="args" locations="locations" simpleMode="$scope.usingCatalogQuickLaunchTags" callback="$close"></brooklyn-quick-launch>

--- a/ui-modules/home/app/views/main/deploy/modal.template.html
+++ b/ui-modules/home/app/views/main/deploy/modal.template.html
@@ -17,4 +17,4 @@
   under the License.
 -->
 <br-svg type="close" class="modal-close pull-right" ng-click="$dismiss('Dismiss deployment modal')"></br-svg>
-<brooklyn-quick-launch app="app" args="args" locations="locations" simpleMode="$scope.usingCatalogQuickLaunchTags" callback="$close"></brooklyn-quick-launch>
+<brooklyn-quick-launch app="app" args="args" locations="locations" callback="$close"></brooklyn-quick-launch>

--- a/ui-modules/home/app/views/main/main.controller.js
+++ b/ui-modules/home/app/views/main/main.controller.js
@@ -50,10 +50,11 @@ export const mainState = {
 
 export function filterCatalogQuickLaunch(list, callbackForFiltered) {
     // optionally tag things with 'catalog_quick_launch': if any apps are so tagged, 
-    // then only apps with such tags will be shown;
-    // in all cases only show those marked as templates.
+    // then only apps with such tags will be shown; otherwise show all marked as templates.
+    
     // the callback is used for clients who wish to adjust their behaviour if tags are used,
     // eg in deploy.controller where noCreateLocationLink is set on the quick launch if there are tagged locations
+    
     if (!list) { 
         list = [];
     }

--- a/ui-modules/utils/quick-launch/quick-launch.html
+++ b/ui-modules/utils/quick-launch/quick-launch.html
@@ -39,7 +39,8 @@
             <h3 class="quick-launch-section-title">Name</h3>
             <div class="quick-launch-section-content">
                 <div class="form-group">
-                    <input class="form-control" type="text" ng-model="model.name" ng-disabled="deploying" name="name" placeholder="Choose a name for this application (Optional)" autofocus />
+                    <input class="form-control" type="text" ng-model="model.name" ng-disabled="deploying" name="name" 
+                        placeholder="{{ 'Choose a name for this application (Optional)' }}" />
                 </div>
             </div>
         </section>
@@ -55,7 +56,7 @@
                            required />
                     <small class="help-block">
                         <span ng-if="deploy.location.$error.required && (deploy.$submitted || deploy.location.$touched)">You must select a location.</span>
-                        <span>Alternatively, you can <a href="/brooklyn-ui-location-manager/#!/wizard">create a new location</a></span>
+                        <span ng-if="!args.noCreateLocationLink">Alternatively, you can <a href="/brooklyn-ui-location-manager/#!/wizard">create a new location</a></span>
                     </small>
                 </div>
             </div>

--- a/ui-modules/utils/quick-launch/quick-launch.js
+++ b/ui-modules/utils/quick-launch/quick-launch.js
@@ -38,7 +38,7 @@ export function quickLaunchDirective() {
         scope: {
             app: '=',
             locations: '=',
-            args: '=?', // default: { noEditButton: false, noComposerButton: false, noCreateLocationLink: false, location: null }
+            args: '=?', // default behaviour of code is: { noEditButton: false, noComposerButton: false, noCreateLocationLink: false, location: null }
             callback: '=?',
         },
         controller: ['$scope', '$http', '$location', 'brSnackbar', controller]

--- a/ui-modules/utils/quick-launch/quick-launch.js
+++ b/ui-modules/utils/quick-launch/quick-launch.js
@@ -38,7 +38,7 @@ export function quickLaunchDirective() {
         scope: {
             app: '=',
             locations: '=',
-            args: '=?',
+            args: '=?', // default: { noEditButton: false, noComposerButton: false, noCreateLocationLink: false, location: null }
             callback: '=?',
         },
         controller: ['$scope', '$http', '$location', 'brSnackbar', controller]
@@ -47,11 +47,21 @@ export function quickLaunchDirective() {
     function controller($scope, $http, $location, brSnackbar) {
         $scope.deploying = false;
         $scope.model = {
-            newConfigFormOpen: false
+            newConfigFormOpen: false,
+            
+            // should never be null, so the placeholder in UI for model.name will never be used;
+            // hence autofocus is disabled
+            name: ($scope.app && ($scope.app.name || $scope.app.symbolicName)) || null, 
         };
         $scope.args = $scope.args || {};
         if ($scope.args.location) {
             $scope.model.location = $scope.args.location;
+        } else {
+            if ($scope.locations) {
+                if ($scope.locations.length == 1) {
+                    $scope.model.location = $scope.locations[0];
+                }
+            } 
         }
         $scope.toggleNewConfigForm = toggleNewConfigForm;
         $scope.addNewConfigKey = addNewConfigKey;


### PR DESCRIPTION
apply catalog_quick_launch tag to filtering locations,
if there is a single location select it automatically,
and if these tags are used, suppress the "create a new location" message --
thus making quick-launch suited for a neatly curated simple mode
where a single preferred location is tagged and you can simply click "deploy"
in quick launch without needing to set anything (assuming default config is valid in the blueprint)