### PR TITLE
Bumps npm, node, and webpack versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
         <pax-web-extender-whiteboard.version>${pax-web.version}</pax-web-extender-whiteboard.version>
 
         <!-- new deps not used in brooklyn-server -->
-        <node.version>v8.4.0</node.version>
-        <npm.version>5.4.1</npm.version>
+        <node.version>v13.2.0</node.version>
+        <npm.version>6.13.1</npm.version>
 
     </properties>
 

--- a/ui-modules/home/package.json
+++ b/ui-modules/home/package.json
@@ -33,8 +33,8 @@
     "e2e": "protractor ./config/test/protractor.config.js"
   },
   "engines": {
-    "node": ">=8.0.0",
-    "npm": ">=5.0.0"
+    "node": ">=13.2.0",
+    "npm": ">=6.13.1"
   },
   "brooklyn": {
     "appname": "Home"
@@ -95,7 +95,7 @@
     "style-loader": "^0.13.0",
     "url": "^0.11.0",
     "url-loader": "^0.5.7",
-    "webpack": "^1.12.12",
+    "webpack": "^1.15.0",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.10.0"
   }


### PR DESCRIPTION
This fixes an issue when trying to build on a clean machine or following the docker build instructions at https://github.com/apache/brooklyn/blob/master/README.md