### PR TITLE
use the flattened pom so that revision is set correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,11 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.0.1</version>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
                 <executions>
                   <!-- enable flattening -->
                   <execution>


### PR DESCRIPTION
brooklyn builds fine without this, but downstream projects get a warning when trying to reference this parent, unless we write the flattened pom to the mvn repo