### PR TITLE
Revert "allow relative path to parent to be configured"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <groupId>org.apache.brooklyn</groupId>
         <artifactId>brooklyn-parent</artifactId>
         <version>1.0.0</version>  <!-- BROOKLYN_VERSION -->
-        <relativePath>${brooklyn.ui.relativePath.to.brooklyn.server.parent}</relativePath>
+        <relativePath>../brooklyn-server/parent/</relativePath>
     </parent>
 
     <groupId>org.apache.brooklyn.ui</groupId>
@@ -84,8 +84,6 @@
         <brooklyn.version>1.0.0</brooklyn.version><!-- BROOKLYN_VERSION -->
         <build.version>${revision}</build.version>
         <build.name>Apache Brooklyn</build.name>
-        <brooklyn.ui.relativePath.to.brooklyn.server.parent>../brooklyn-server/parent/</brooklyn.ui.relativePath.to.brooklyn.server.parent>
-
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
 
         <!-- versions from brooklyn server which have a different var name here -->


### PR DESCRIPTION
This reverts commit e8dec48eae0b07d1d2918c7315b1090e5c856345.

Seems maven doesn't actually respect a variable in relative path. I must have been taking some cached or downloaded item when i tested, as when we change the version it breaks.

Also irritating, seems maven won't look in the local reactor model so we need either relative path to work or the upstream item to have been built.