### PR TITLE
Use consistent version numbers

### DIFF
--- a/modularity-server/external-modules/pom.xml
+++ b/modularity-server/external-modules/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-utils-test-support</artifactId>
-            <version>${project.version}</version>
+            <version>${brooklyn.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modularity-server/metadata-registry/pom.xml
+++ b/modularity-server/metadata-registry/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-utils-test-support</artifactId>
-            <version>${project.version}</version>
+            <version>${brooklyn.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modularity-server/module-api/pom.xml
+++ b/modularity-server/module-api/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-utils-test-support</artifactId>
-            <version>${project.version}</version>
+            <version>${brooklyn.version}</version>
             <scope>test</scope>
         </dependency>
             

--- a/modularity-server/proxy/pom.xml
+++ b/modularity-server/proxy/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-utils-test-support</artifactId>
-            <version>${project.version}</version>
+            <version>${brooklyn.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
brooklyn dependencies use brooklyn.version normally except for a few
places.  Changed for consistency.