### PR TITLE
Remove initial filter if no results

### DIFF
--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -206,6 +206,8 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             scope.state.config.add.list = getAddListConfig();
         });
 
+        removeFilterIfAllItemsHidden();
+
         loadCustomConfigWidgetMetadata(scope);
 
         // Model
@@ -811,6 +813,14 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                     scope.state.config.customConfigWidgetMetadata[k] = angular.extend({enabled: true}, scope.state.config.customConfigWidgetMetadata[k], wd);
                 });
             });
+        }
+
+        function removeFilterIfAllItemsHidden() {
+            let filteredItems = getAddListConfig();
+            if (filteredItems.length > 0 && filteredItems.filter(item => !item.isHidden).length === 0) {
+                scope.state.config.filter.values['all'] = true;
+                console.log(scope.state.config.filter);
+            }
         }
 
         /**

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -819,7 +819,6 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             let filteredItems = getAddListConfig();
             if (filteredItems.length > 0 && filteredItems.filter(item => !item.isHidden).length === 0) {
                 scope.state.config.filter.values['all'] = true;
-                console.log(scope.state.config.filter);
             }
         }
 


### PR DESCRIPTION
When the spec editor first opens the filters are set to 'Suggested' 'Required' and 'In Use'.
This may result in no results being shown which is confusing to the user as it's not immediately obvious that there are filters in use.

In this situation we add the 'All' filter to show all results. Subsequent operation of the filters is unaffected.