### PR TITLE
Use `===` to not only check the value but type

### DIFF
--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -507,7 +507,7 @@
                         <div class="input-group" ng-switch-default>
                             <span class="main-control span-for-rounded-edge">
                                 <textarea ng-model="config[item.name]" class="form-control rounded-edge" name="{{item.name}}" id="{{item.name}}" auto-grow
-                                      placeholder="{{defined(config[item.name]) ? null : item.defaultValue=='' || item.defaultValue==null ? '(empty)' : item.defaultValue}}"
+                                      placeholder="{{defined(config[item.name]) ? null : item.defaultValue === '' || item.defaultValue === null ? '(empty)' : item.defaultValue}}"
                                       ng-focus="specEditor.recordConfigFocus(item)" on-enter="specEditor.advanceOutToFormGroupInPanel"></textarea>
                             </span>
                             <span class="input-group-btn dsl-wizard-button rounded-edge" ng-if="specEditor.isDslWizardButtonAllowed(item.name)">


### PR DESCRIPTION
On the spec editor, if an entity has a configuration key of type `integer`, with a `defaultValue` of `0`, then the `Configuration` section displayed `(empty)` because `defaultValue == ''` is true, whereas `defaultValue === ''` is false, which is what we want