### PR TITLE
Add support for downloading bundle as ZIP files

### DIFF
--- a/ui-modules/catalog/app/views/bundle/bundle.state.js
+++ b/ui-modules/catalog/app/views/bundle/bundle.state.js
@@ -84,6 +84,10 @@ export function bundleController($scope, $state, $stateParams, brSnackbar, brUti
         });
     };
 
+    $scope.downloadBundle = () => {
+        return catalogApi.downloadBundle($scope.bundle.symbolicName, $scope.bundle.version, {urlOnly: true});
+    }
+
     $scope.isNonEmpty = (o) => {
         return brUtilsGeneral.isNonEmpty(o);
     };

--- a/ui-modules/catalog/app/views/bundle/bundle.template.html
+++ b/ui-modules/catalog/app/views/bundle/bundle.template.html
@@ -37,6 +37,9 @@
                                     </li>
                                 </ul>
                             </div>
+                            <a class="btn btn-sm btn-default" ng-href="{{downloadBundle()}}">
+                                <i class="fa fa-fw fa-download"></i> Download
+                            </a>
                         </h4>
                         <p class="media-auto-wrap text-muted" ng-if="bundle.symbolicName.startsWith('brooklyn-catalog-bom')"><small>
                             <i class="fa fa-fw fa-info-circle"></i> Bundle auto-generated from an uploaded BOM file

--- a/ui-modules/utils/providers/catalog-api.provider.js
+++ b/ui-modules/utils/providers/catalog-api.provider.js
@@ -188,4 +188,11 @@ class CatalogApiProvider extends CatalogApi {
             .catch(new ErrorHandler(deferred));
         return deferred.promise;
     }
+
+    downloadBundle(bundleSymbolicName, bundleVersion, config) {
+        const url = `${this.host}/v1/catalog/bundles/${bundleSymbolicName}/${bundleVersion}/download`;
+        return config.urlOnly === true
+            ? url
+            : this.$http.get(`${this.host}/v1/catalog/bundles/${bundleSymbolicName}/${bundleVersion}/download`, angular.extend({}, config));
+    }
 }


### PR DESCRIPTION
This adds a new `Download` button on the bundle page that let a user downloading the current bundle as a ZIP file.

![Screenshot 2020-12-03 at 10 20 53](https://user-images.githubusercontent.com/2082759/100996661-3b648a80-3551-11eb-87dd-0958207566ba.png)

This requires https://github.com/apache/brooklyn-server/pull/1131 to work