### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: java
-cache:
-  directories:
-  - $HOME/.m2
-  - node_modules # NPM packages


### PR DESCRIPTION
PRs and nightlies are built by Apache Jenkins provided by INFRA. Something must have changed in GitHub or Apache Jenkins to start triggering build on Travis CI. 

Regardless, we don't need this hence the removal