### PR TITLE
Make the blueprint composer tabs customisable by downstream projects

### DIFF
--- a/ui-modules/app-inspector/app/index.html
+++ b/ui-modules/app-inspector/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di>
+    <body ng-app="brooklynAppInspector" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/app-inspector/app/index.js
+++ b/ui-modules/app-inspector/app/index.js
@@ -60,9 +60,11 @@ import {streamState} from "views/main/inspect/activities/detail/stream/stream.co
 import {catalogApiProvider} from "brooklyn-ui-utils/providers/catalog-api.provider";
 import {apiObserverInterceptorProvider} from "brooklyn-ui-utils/providers/api-observer-interceptor.provider";
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngResource, ngCookies, ngSanitize, uiRouter, brCore, brUtilsGeneral, brServerStatus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brSensitiveField, brooklynUserManagement, brYamlEditor, brWebNotifications, brExpandablePanel, 'xeditable', apiProvider, entityTree, loadingState, configSensorTable, entityEffector, entityPolicy, breadcrumbNavigation, taskList, taskSunburst, stream, adjunctsList, managementDetail])
+angular.module('brooklynAppInspector', [ngResource, ngCookies, ngSanitize, uiRouter, brCore, brUtilsGeneral, brServerStatus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brSensitiveField, brooklynUserManagement, brYamlEditor, brWebNotifications, brExpandablePanel, 'xeditable', apiProvider, entityTree, loadingState, configSensorTable, entityEffector, entityPolicy, breadcrumbNavigation, taskList, taskSunburst, stream, adjunctsList, managementDetail, brandAngularJs])
     .provider('catalogApi', catalogApiProvider)
     .provider('apiObserverInterceptor', apiObserverInterceptorProvider)
     .filter('specToLabel', specToLabelFilter)

--- a/ui-modules/app-inspector/package.json
+++ b/ui-modules/app-inspector/package.json
@@ -40,7 +40,6 @@
     "appname": "App inspector"
   },
   "dependencies": {
-    "brooklyn-ui-utils": "file:../utils",
     "angular": "^1.6.1",
     "angular-animate": "^1.6.1",
     "angular-cookies": "^1.6.1",
@@ -50,6 +49,7 @@
     "angular-ui-router": "^0.3.1",
     "angular-xeditable": "^0.4.0",
     "bootstrap": "^3.3.7",
+    "brooklyn-ui-utils": "file:../utils",
     "d3": "4.10.0",
     "es6-promise": "^4.0.5",
     "font-awesome": "^4.6.3",

--- a/ui-modules/blueprint-composer/app/components/providers/tab-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/tab-service.provider.js
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import angular from 'angular';
+
+const MODULE_NAME = 'brooklyn.composer.service.tab-service';
+
+angular.module(MODULE_NAME, [])
+    .provider('tabService', actionServiceProvider);
+
+export default MODULE_NAME;
+
+export function actionServiceProvider() {
+    let tabs = {};
+    return {
+        $get: function () {
+            return new TabService(tabs);
+        },
+        addTab(id, tab) {
+            tabs[id] = tab;
+        },
+        deleteTab(id) {
+            delete tabs[id];
+        }
+    }
+}
+
+class TabService {
+    constructor(tabsToAdd) {
+        this.tabs = [];
+        this.requiredFields = ['title', 'stateKey'];
+
+        for (const [id, tab] of Object.entries(tabsToAdd)) {
+            this.addTab(id, tab);
+        }
+    }
+
+    addTab(id, tab) {
+        if (!id) {
+            throw `ID for tab ${JSON.stringify(tab)} must ve a non-empty value`;
+        }
+        if (!tab) {
+            throw `Tab "${id}" must be a valid object`;
+        }
+        this.requiredFields.forEach(field => {
+            if (!tab[field]) {
+                throw `Tab "${id}" must have a non-empty "${field}" property`;
+            }
+        });
+        if (this.tabs.some(tab => tab.id === id)) {
+            throw `Tab with "${id}" already exists`;
+        }
+        this.tabs.push(Object.assign({
+            id: id,
+            order: 0
+        }, tab));
+    }
+
+    getTabs() {
+        return this.tabs.sort((a, b) => a.order - b.order);
+    }
+}

--- a/ui-modules/blueprint-composer/app/index.html
+++ b/ui-modules/blueprint-composer/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di>
+    <body ng-app="brooklynBlueprintComposer" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -72,14 +72,16 @@ import stackViewer from 'angular-java-stack-viewer';
 import {EntityFamily} from "./components/util/model/entity.model";
 import scriptTagDecorator from 'brooklyn-ui-utils/script-tag-non-overwrite/script-tag-non-overwrite';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 'ui.router.state.events', brCore,
+angular.module('brooklynBlueprintComposer', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 'ui.router.state.events', brCore,
     brServerStatus, brAutoFocus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement,
     brYamlEditor, brUtils, brSpecEditor, brooklynCatalogSaver, brooklynApi, bottomSheet, stackViewer, brDragndrop,
     customActionDirective, customConfigSuggestionDropdown, paletteApiProvider, paletteServiceProvider, blueprintLoaderApiProvider,
     breadcrumbs, catalogSelector, designer, objectCache, entityFilters, locationFilter, actionService, tabService, blueprintService,
-    dslService, paletteDragAndDropService, recentlyUsedService, scriptTagDecorator])
+    dslService, paletteDragAndDropService, recentlyUsedService, scriptTagDecorator, brandAngularJs])
     .provider('composerOverrides', composerOverridesProvider)
     .filter('dslParamLabel', ['$filter', dslParamLabelFilter])
     .config(['$urlRouterProvider', '$stateProvider', '$logProvider', '$compileProvider', applicationConfig])

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -56,6 +56,7 @@ import recentlyUsedService from "./components/providers/recently-used-service.pr
 import dslService from "./components/providers/dsl-service.provider";
 import paletteDragAndDropService from "./components/providers/palette-dragndrop.provider";
 import actionService from "./components/providers/action-service.provider";
+import tabService from "./components/providers/tab-service.provider";
 import {mainState} from "./views/main/main.controller";
 import {yamlState} from "./views/main/yaml/yaml.state";
 import {graphicalState} from "./views/main/graphical/graphical.state";
@@ -77,12 +78,13 @@ angular.module('app', [ngAnimate, ngResource, ngCookies, ngClipboard, uiRouter, 
     brServerStatus, brAutoFocus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement,
     brYamlEditor, brUtils, brSpecEditor, brooklynCatalogSaver, brooklynApi, bottomSheet, stackViewer, brDragndrop,
     customActionDirective, customConfigSuggestionDropdown, paletteApiProvider, paletteServiceProvider, blueprintLoaderApiProvider,
-    breadcrumbs, catalogSelector, designer, objectCache, entityFilters, locationFilter, actionService, blueprintService,
+    breadcrumbs, catalogSelector, designer, objectCache, entityFilters, locationFilter, actionService, tabService, blueprintService,
     dslService, paletteDragAndDropService, recentlyUsedService, scriptTagDecorator])
     .provider('composerOverrides', composerOverridesProvider)
     .filter('dslParamLabel', ['$filter', dslParamLabelFilter])
     .config(['$urlRouterProvider', '$stateProvider', '$logProvider', '$compileProvider', applicationConfig])
     .config(['actionServiceProvider', actionConfig])
+    .config(['tabServiceProvider', tabConfig])
     .config(['paletteServiceProvider', paletteConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])
     .run(['$http', httpConfig]);
@@ -118,6 +120,19 @@ function composerOverridesProvider() {
 function actionConfig(actionServiceProvider) {
     actionServiceProvider.addAction("deploy", {html: '<button class="btn btn-outline btn-success" ng-click="vm.deployApplication()" ng-disabled="vm.deploying">Deploy</button>'});
     actionServiceProvider.addAction("add", {html: '<catalog-saver config="vm.saveToCatalogConfig"></catalog-saver>'});
+}
+
+function tabConfig(tabServiceProvider) {
+    tabServiceProvider.addTab('graphical', {
+        title: 'Graphical Designer',
+        icon: 'fa-object-group',
+        stateKey: 'main.graphical'
+    });
+    tabServiceProvider.addTab('yaml', {
+        title: 'YAML Editor',
+        icon: 'fa-pencil',
+        stateKey: 'main.yaml',
+    });
 }
 
 function paletteConfig(paletteServiceProvider) {

--- a/ui-modules/blueprint-composer/app/views/main/main.controller.js
+++ b/ui-modules/blueprint-composer/app/views/main/main.controller.js
@@ -56,7 +56,7 @@ const layers = [
 ];
 const layerCacheKey = 'blueprint-composer.layers';
 
-export function MainController($scope, $element, $log, $state, $stateParams, brBrandInfo, blueprintService, actionService, catalogApi, applicationApi, brSnackbar, brBottomSheet, edit, yaml, composerOverrides) {
+export function MainController($scope, $element, $log, $state, $stateParams, brBrandInfo, blueprintService, actionService, tabService, catalogApi, applicationApi, brSnackbar, brBottomSheet, edit, yaml, composerOverrides) {
     $scope.$emit(HIDE_INTERSTITIAL_SPINNER_EVENT);
     let vm = this;
 
@@ -131,13 +131,10 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
         
         yaml = edit.type.plan.data;
     }
-    
-    vm.isGraphicalMode = () => {
-        return $state.includes(graphicalState.name);
-    };
-    vm.isYamlMode = () => {
-        return $state.includes(yamlState.name);
-    };
+
+    vm.isTabActive = stateKey => {
+        return $state.is(stateKey);
+    }
 
     if (yaml) {
         if (vm.isYamlMode()) {
@@ -168,6 +165,10 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
 
     vm.getAllActions = () => {
         return actionService.getActions();
+    }
+
+    vm.getAllTabs = () => {
+        return tabService.getTabs();
     }
 
     vm.displayIssues = () => {
@@ -277,7 +278,7 @@ export const mainState = {
     url: '/?bundleSymbolicName&bundleVersion&typeSymbolicName&typeVersion&yaml',
     abstract: true,
     template: template,
-    controller: ['$scope', '$element', '$log', '$state', '$stateParams', 'brBrandInfo', 'blueprintService', 'actionService', 'catalogApi', 'applicationApi', 'brSnackbar', 'brBottomSheet', 'edit', 'yaml', 'composerOverrides', MainController],
+    controller: ['$scope', '$element', '$log', '$state', '$stateParams', 'brBrandInfo', 'blueprintService', 'actionService', 'tabService', 'catalogApi', 'applicationApi', 'brSnackbar', 'brBottomSheet', 'edit', 'yaml', 'composerOverrides', MainController],
     controllerAs: 'vm',
     resolve: {
         edit: ['$stateParams', 'blueprintLoaderApi', ($stateParams, blueprintLoaderApi) => blueprintLoaderApi.loadBlueprint($stateParams)],

--- a/ui-modules/blueprint-composer/app/views/main/main.template.html
+++ b/ui-modules/blueprint-composer/app/views/main/main.template.html
@@ -21,14 +21,9 @@
     <nav class="navbar navbar-mode">
         <div class="container-fluid flush-left">
             <ul class="nav navbar-nav navbar-nav-mode">
-                <li ng-class="{'active': vm.isGraphicalMode()}">
-                    <a ui-sref="main.graphical" ng-disabled="vm.parseError">
-                        <i class="fa fa-fw fa-object-group"></i> Graphical Designer
-                    </a>
-                </li>
-                <li ng-class="{'active': !vm.isGraphicalMode()}">
-                    <a ui-sref="main.yaml">
-                        <i class="fa fa-fw fa-pencil"></i> YAML Editor
+                <li ng-repeat="tab in vm.getAllTabs() track by tab.id" ng-class="{'active': vm.isTabActive(tab.stateKey)}">
+                    <a ui-sref="{{tab.stateKey}}">
+                        <i ng-if="tab.icon" class="fa fa-fw {{tab.icon}}"></i> {{tab.title}}
                     </a>
                 </li>
             </ul>

--- a/ui-modules/blueprint-composer/package.json
+++ b/ui-modules/blueprint-composer/package.json
@@ -40,7 +40,6 @@
     "appname": "Blueprint composer"
   },
   "dependencies": {
-    "brooklyn-ui-utils": "file:../utils",
     "angular": "^1.7.2",
     "angular-animate": "^1.7.2",
     "angular-cookies": "^1.7.2",
@@ -51,6 +50,7 @@
     "angular-ui-router": "^1.0.18",
     "angular-xeditable": "^0.4.0",
     "bootstrap": "^3.3.7",
+    "brooklyn-ui-utils": "file:../utils",
     "codemirror": "^5.19.0",
     "d3": "4.10.0",
     "date-fns": "^1.29.0",

--- a/ui-modules/blueprint-importer/app/index.html
+++ b/ui-modules/blueprint-importer/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di>
+    <body ng-app="brooklynBlueprintComposer" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/blueprint-importer/app/index.js
+++ b/ui-modules/blueprint-importer/app/index.js
@@ -32,9 +32,11 @@ import uiRouter from 'angular-ui-router';
 
 import mainState from 'views/main/main.controller.js';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngCookies, ngResource, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, uiRouter, mainState])
+angular.module('brooklynBlueprintImporter', [ngAnimate, ngCookies, ngResource, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, uiRouter, mainState, brandAngularJs])
     .config(['$logProvider', '$compileProvider', appConfig])
     .config(['$urlRouterProvider', routerConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])

--- a/ui-modules/branding/brand-angular.js
+++ b/ui-modules/branding/brand-angular.js
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* File where brands can provide JS extensions available as angular modules.
+ * If supplied, they must supply all elements declared by the stock Brooklyn implementation.
+ * It can be omitted from a brand.
+ *
+ * The entries returned by the `brBrandInfoProvider` here can be accessed in `brBrandInfo` by passing that module to an angular module.
+ */
+import angular from 'angular';
+
+export const MODULE_NAME = 'brooklyn.brand.extensionPoint.angularJs';
+
+export default MODULE_NAME;
+
+// This module is loaded last on all Brooklyn UI modules. That means downstream project
+// can override it to perform any customization to providers, services, router states, decorators, etc.
+angular.module(MODULE_NAME, []);

--- a/ui-modules/catalog/app/index.html
+++ b/ui-modules/catalog/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di brooklyn-catalog-uploader="open-catalog-uploader">
+    <body ng-app="brooklynCatalog" br-server-status ng-strict-di brooklyn-catalog-uploader="open-catalog-uploader">
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/catalog/app/index.js
+++ b/ui-modules/catalog/app/index.js
@@ -35,9 +35,11 @@ import catalogState from './views/catalog/catalog.state';
 import catalogBundleState from './views/bundle/bundle.state';
 import catalogBundleTypeState from './views/bundle/type/type.state';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngCookies, ngResource, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brooklynCatalogUpdater, uiRouter, catalogState, catalogBundleState, catalogBundleTypeState])
+angular.module('brooklynCatalog', [ngAnimate, ngCookies, ngResource, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brooklynCatalogUpdater, uiRouter, catalogState, catalogBundleState, catalogBundleTypeState, brandAngularJs])
     .config(['$logProvider', '$compileProvider', applicationConfig])
     .config(['$urlRouterProvider', routerConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])

--- a/ui-modules/groovy-console/app/index.html
+++ b/ui-modules/groovy-console/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di>
+    <body ng-app="brooklynGroovyConsole" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/groovy-console/app/index.js
+++ b/ui-modules/groovy-console/app/index.js
@@ -30,9 +30,11 @@ import brooklynUserManagement from 'brooklyn-ui-utils/user-management/user-manag
 
 import mainState from 'views/main/main.controller';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, mainState])
+angular.module('brooklynGroovyConsole', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, mainState, brandAngularJs])
     .config(['$logProvider', '$compileProvider', appConfig])
     .config(['$urlRouterProvider', '$stateProvider', routerConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])

--- a/ui-modules/home/app/index.html
+++ b/ui-modules/home/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name' )%> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di>
+    <body ng-app="brooklynHome" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header-hero.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/home/app/index.js
+++ b/ui-modules/home/app/index.js
@@ -34,9 +34,11 @@ import mainState from 'views/main/main.controller';
 import mainDeployState from 'views/main/deploy/deploy.controller';
 import aboutState from 'views/about/about.controller.js';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brooklynQuickLaunch, mainState, mainDeployState, aboutState])
+angular.module('brooklynHome', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brIconGenerator, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brooklynQuickLaunch, mainState, mainDeployState, aboutState, brandAngularJs])
     .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$http', httpConfig]);
 

--- a/ui-modules/location-manager/app/index.html
+++ b/ui-modules/location-manager/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di>
+    <body ng-app="brooklynLocationManager" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/location-manager/app/index.js
+++ b/ui-modules/location-manager/app/index.js
@@ -38,9 +38,11 @@ import wizardAdvancedState from 'views/wizard/advanced/advanced.controller';
 import wizardByonState from 'views/wizard/byon/byon.controller';
 import wizardCloudState from 'views/wizard/cloud/cloud.controller';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brAutoFocus, brInterstitialSpinner, brooklynModuleLinks, brSensitiveField, brooklynUserManagement, brooklynApi, locationsState, detailState, wizardState, wizardAdvancedState, wizardByonState, wizardCloudState])
+angular.module('brooklynLocationManager', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brAutoFocus, brInterstitialSpinner, brooklynModuleLinks, brSensitiveField, brooklynUserManagement, brooklynApi, locationsState, detailState, wizardState, wizardAdvancedState, wizardByonState, wizardCloudState, brandAngularJs])
     .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])
     .run(['$http', httpConfig]);

--- a/ui-modules/logout/app/index.html
+++ b/ui-modules/logout/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name' )%> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" ng-strict-di>
+    <body ng-app="brooklynLogout" ng-strict-di>
     ${require('ejs-html!brooklyn-shared/partials/header-hero.html')}
 
     <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/logout/app/index.js
+++ b/ui-modules/logout/app/index.js
@@ -30,9 +30,11 @@ import brServerStatus from 'brooklyn-ui-utils/server-status/server-status';
 
 import mainState from './views/main/main.controller';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brInterstitialSpinner, brServerStatus, brooklynModuleLinks, brooklynUserManagement, mainState])
+angular.module('brooklynLogout', [ngAnimate, ngCookies, uiRouter, brCore, brInterstitialSpinner, brServerStatus, brooklynModuleLinks, brooklynUserManagement, mainState, brandAngularJs])
     .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$http', httpConfig]);
 

--- a/ui-modules/rest-api-docs/app/index.html
+++ b/ui-modules/rest-api-docs/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="app" br-server-status ng-strict-di>
+    <body ng-app="brooklynRestApiDocs" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/rest-api-docs/app/index.js
+++ b/ui-modules/rest-api-docs/app/index.js
@@ -30,9 +30,11 @@ import brooklynUserManagement from 'brooklyn-ui-utils/user-management/user-manag
 
 import mainState from 'views/main/main.controller.js';
 
+import brandAngularJs from 'brand-angular-js';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
-angular.module('app', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, mainState])
+angular.module('brooklynRestApiDocs', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, mainState, brandAngularJs])
     .config(['$logProvider', '$compileProvider', appConfig])
     .config(['$urlRouterProvider', routerConfig])
     .run(['$rootScope', '$state', 'brSnackbar', errorHandler])

--- a/ui-modules/shared/config/build/webpack.config.js
+++ b/ui-modules/shared/config/build/webpack.config.js
@@ -140,6 +140,7 @@ const config = {
             'brand-fallback': BRAND_FALLBACK_DIR,
             // brand-supplied JS definitions
             'brand-js': fs.existsSync(pj(BRAND_DIR, 'brand.js')) ? pj(BRAND_DIR, 'brand.js') : pj(BRAND_FALLBACK_DIR, 'brand.js'),
+            'brand-angular-js': fs.existsSync(pj(BRAND_DIR, 'brand-angular.js')) ? pj(BRAND_DIR, 'brand-angular.js') : pj(BRAND_FALLBACK_DIR, 'brand-angular.js'),
         },
         root: SRC_DIR,
         extensions: ['', '.js'],


### PR DESCRIPTION
Each "tab" is added via a new `TabProvider` and can be removed/updated later on by the application config hook. Each tab is an object with the following properties:
- `title`: the tab title that is going to appears on the tab bar
- `stateKey`: the key of the state to switch to when the tab is clicked on
- `icon`: (optional) the class name for the font-awesome icon to use