### PR TITLE
Expose the CodeMirror instance that can be accessed via an event

### DIFF
--- a/ui-modules/utils/yaml-editor/yaml-editor.js
+++ b/ui-modules/utils/yaml-editor/yaml-editor.js
@@ -177,5 +177,11 @@ export function yamlEditorDirective($rootScope, brSnackbar) {
                 $scope.cm.refresh();
             });
         });
+
+        $scope.$on(`${MODULE_NAME}.cm`, callback => {
+            if (angular.isFunction(callback)) {
+                callback.apply(null, [$scope.cm]);
+            }
+        });
     }
 }


### PR DESCRIPTION
The YAML editor can now listen for an event with name `brooklyn.component.yaml-editor.cm` and will execute the given callback with the CodeMirror instance. That allows downstream project to use directly `CodeMirror` if they wish too.