### PR TITLE
Switch the linters to be asynchronous.

### DIFF
--- a/ui-modules/utils/yaml-editor/addon/lint/lint-yaml-tab.js
+++ b/ui-modules/utils/yaml-editor/addon/lint/lint-yaml-tab.js
@@ -19,22 +19,24 @@
 const CodeMirror = require('codemirror');
 
 CodeMirror.registerGlobalHelper('lint', 'yaml-tab', mode => mode.name === 'yaml', (text, options, cm) => {
-    let issues = [];
+    return new Promise(resolve => {
+        let issues = [];
 
-    for (let index = 0; index < cm.lineCount(); index++) {
-        cm.getLine(index)
-            .split('')
-            .map((c, i) => ({c: c, i: i}))
-            .filter(item => item.c === '\t')
-            .forEach(item => {
-                issues.push({
-                    from: CodeMirror.Pos(index, item.i),
-                    to: CodeMirror.Pos(index, item.i + 1),
-                    message: 'Tab character detected. We strongly recommend you to use spaces instead to avoid indentation issues',
-                    severity: 'warning'
+        for (let index = 0; index < cm.lineCount(); index++) {
+            cm.getLine(index)
+                .split('')
+                .map((c, i) => ({c: c, i: i}))
+                .filter(item => item.c === '\t')
+                .forEach(item => {
+                    issues.push({
+                        from: CodeMirror.Pos(index, item.i),
+                        to: CodeMirror.Pos(index, item.i + 1),
+                        message: 'Tab character detected. We strongly recommend you to use spaces instead to avoid indentation issues',
+                        severity: 'warning'
+                    });
                 });
-            });
-    }
+        }
 
-    return issues;
+        resolve(issues);
+    });
 });


### PR DESCRIPTION
Because CodeMirror can have only on type of linters when an instance is created (it's either sync or async, cannot have a combination of both) it will restrict at some point what linters downstream projects can define for the composer.

Better to switch the current ones to async so everyone can take advantage of promises.