### PR TITLE
Use the correct AngularJs module name for blueprint importer

### DIFF
--- a/ui-modules/blueprint-importer/app/index.html
+++ b/ui-modules/blueprint-importer/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name') %> - <%= app.appname %></title>
     </head>
-    <body ng-app="brooklynBlueprintComposer" br-server-status ng-strict-di>
+    <body ng-app="brooklynBlueprintImporter" br-server-status ng-strict-di>
         ${require('ejs-html!brooklyn-shared/partials/header.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>


### PR DESCRIPTION
Currently, it will throw an error when the module is started, making it unusable.