### PR TITLE
fix isYamlMode bug and placeholder for auto-detecting yaml state

### DIFF
--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -58,7 +58,7 @@ import paletteDragAndDropService from "./components/providers/palette-dragndrop.
 import actionService from "./components/providers/action-service.provider";
 import tabService from "./components/providers/tab-service.provider";
 import {mainState} from "./views/main/main.controller";
-import {yamlState} from "./views/main/yaml/yaml.state";
+import {yamlAutodetectState, yamlCampState, yamlState} from "./views/main/yaml/yaml.state";
 import {graphicalState} from "./views/main/graphical/graphical.state";
 import {graphicalEditState} from "./views/main/graphical/edit/edit.controller";
 import {graphicalEditAddState} from "./views/main/graphical/edit/add/add";
@@ -98,7 +98,8 @@ function applicationConfig($urlRouterProvider, $stateProvider, $logProvider, $co
         .otherwise(graphicalState.url);
     $stateProvider
         .state(mainState)
-        .state(yamlState)
+        .state(yamlAutodetectState)
+        .state(yamlCampState)
         .state(graphicalState)
         .state(graphicalEditAddState)
         .state(graphicalEditState)
@@ -163,7 +164,7 @@ function paletteConfig(paletteServiceProvider) {
 function errorHandler($rootScope, $state, brSnackbar) {
     $rootScope.$on('$stateChangeError', (event, toState, toParams, fromState, fromParams, error) => {
         brSnackbar.create(error.detail);
-        if (toState === yamlState) {
+        if (toState && toState.name && toState.name.startsWith(yamlAutodetectState.name)) {
             $state.go(toState);
         } else {
             $state.go(graphicalState);

--- a/ui-modules/blueprint-composer/app/views/main/main.controller.js
+++ b/ui-modules/blueprint-composer/app/views/main/main.controller.js
@@ -20,7 +20,7 @@ import {HIDE_INTERSTITIAL_SPINNER_EVENT} from 'brooklyn-ui-utils/interstitial-sp
 import template from './main.template.html';
 import {EntityFamily} from '../../components/util/model/entity.model';
 import {graphicalState} from './graphical/graphical.state';
-import {yamlState} from './yaml/yaml.state';
+import {yamlAutodetectState} from './yaml/yaml.state';
 import {graphicalEditEntityState} from './graphical/edit/entity/edit.entity.controller';
 import {graphicalEditPolicyState} from './graphical/edit/policy/edit.policy.controller';
 import {graphicalEditEnricherState} from './graphical/edit/enricher/edit.enricher.controller';
@@ -97,7 +97,7 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
     $scope.$on('blueprint.reset', () => {
         vm.saveToCatalogConfig = {};
         blueprintService.reset();
-        $state.go($state.includes(yamlState) ? yamlState : graphicalState, {}, {inherit: false, reload: true});
+        $state.go(vm.isYamlMode() ? $state : graphicalState, {}, {inherit: false, reload: true});
     });
     $scope.$on('blueprint.deploy', () => {
         vm.deployApplication();
@@ -134,6 +134,9 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
 
     vm.isTabActive = stateKey => {
         return $state.is(stateKey);
+    }
+    vm.isYamlMode = () => {
+        return $state.includes(yamlAutodetectState.name);
     }
 
     if (yaml) {

--- a/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
@@ -19,9 +19,21 @@
 import CodeMirror from 'codemirror';
 import {YAMLException} from 'js-yaml';
 
-export const yamlState = {
+
+export const yamlAutodetectState = {
+    // TODO make this do auto-detect
     name: 'main.yaml',
     url: 'yaml',
+    template: '<br-yaml-editor value="vm.yaml" type="blueprint"></br-yaml-editor>',
+    controller: ['$scope', '$rootScope', '$timeout', 'blueprintService', 'brSnackbar', yamlStateController],
+    controllerAs: 'vm',
+    data: {
+        label: 'YAML Editor'
+    }
+}
+export const yamlCampState = {
+    name: 'main.yaml.camp',
+    url: 'camp',
     template: '<br-yaml-editor value="vm.yaml" type="blueprint"></br-yaml-editor>',
     controller: ['$scope', '$rootScope', '$timeout', 'blueprintService', 'brSnackbar', yamlStateController],
     controllerAs: 'vm',


### PR DESCRIPTION
the previous refactor left a reference to `isYamlMode` which it removed.  this reinstates that.

we will also want better redirection from the `/yaml?blueprint=xxxx` endpoint links from catalog for those cases where the blueprint is in a non-CAMP format, to allow the correct tab to display.  this adds some placeholder logic for that but does not implement it.