### PR TITLE
remove units from minRam in location wizard

### DIFF
--- a/ui-modules/location-manager/app/components/location-utils/location-utils.js
+++ b/ui-modules/location-manager/app/components/location-utils/location-utils.js
@@ -41,9 +41,8 @@ export function locationConfigProvider() {
                 type: 'number'
             },
             'minRam': {
-                description: 'Minimum amount of RAM for the generated VM',
-                type: 'number',
-                unit: 'Mb'
+                description: 'Minimum amount of RAM for the generated VM, e.g. "16 gb"; defaults to "mb" if no units specified',
+                type: 'text',
             },
             'osFamily': {
                 description: 'Operating system to use for the generated VM',


### PR DESCRIPTION
so that people can specify "16 gb" which is more natural than requiring eg "16384" (units hardcoded as "Mb")