### PR TITLE
blueprint composer can show annotations

### DIFF
--- a/ui-modules/blueprint-composer/app/components/designer/designer.less
+++ b/ui-modules/blueprint-composer/app/components/designer/designer.less
@@ -231,5 +231,14 @@ designer {
         .arrowhead-highlight {
             fill: @brand-primary;
         }
+
+        .annotation {
+            padding: 2px 5px;
+            border-radius: 4px;
+            opacity: 0.8;
+            overflow: scroll;
+            display: flex;
+            align-items: center;
+        }
     }
 }

--- a/ui-modules/blueprint-composer/app/views/main/main.controller.js
+++ b/ui-modules/blueprint-composer/app/views/main/main.controller.js
@@ -52,7 +52,13 @@ const LAYERS = [
         label: 'Relationships',
         selector: '.relation-group',
         active: true
-    }
+    },
+    {
+        id: 'annotations',
+        label: 'Annotations',
+        selector: '.node-annotation',
+        active: true
+    },
 ];
 const LAYER_CACHE_KEY = 'blueprint-composer.layers';
 

--- a/ui-modules/blueprint-composer/package.json
+++ b/ui-modules/blueprint-composer/package.json
@@ -59,6 +59,7 @@
     "font-awesome": "^4.6.3",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.16.4",
+    "marked": "^2.0.1",
     "ngclipboard": "^1.1.1",
     "normalizr": "^2.2.1",
     "underscore": "^1.8.3"


### PR DESCRIPTION
based on a `ui-composer-annotation` tag with text value or object value, rendering as markdown

see docs PR to follow immediately

teaser screenshot

![image](https://user-images.githubusercontent.com/496540/120346606-6e66bb80-c2f3-11eb-9680-1057ca9dd1e2.png)

from code

```
name: Annotation Sample
services:
  - type: aws_s3_bucket
    brooklyn.tags:
      - ui-composer-annotation: A simple default annotation
      - ui-composer-annotation:
          text: >-
            Shown below, yellow text, centered with CSS. Because it's long, scroll bars horizontally and vertically shown when
            needed.
          styleInnerDiv: 'margin: auto; color: yellow;'
          'y': 120
  - type: aws_s3_bucket
    brooklyn.tags:
      - ui-composer-annotation:
          text: |
            ## Big Example
            A **red** tag at _right_, using markdown, in a big box.
          width: 300
          height: 200
          x: 220
          'y': 0
          background: '#ffcccc'
          style: 'font-size: 9px;'
```