### PR TITLE
Switch relationships with path and label selector rather than group selector

### DIFF
--- a/ui-modules/blueprint-composer/app/components/designer/designer.less
+++ b/ui-modules/blueprint-composer/app/components/designer/designer.less
@@ -225,6 +225,16 @@ designer {
                 opacity: 0;
             }
         }
+        .relation-text {
+            fill: @color-relation;
+            opacity: 1;
+            &.highlight {
+                fill: @brand-primary;
+            }
+            &.hidden {
+                opacity: 0;
+            }
+        }
         .arrowhead {
             fill: @color-relation;
         }

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -93,8 +93,8 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                     source: entity,
                     target: relation.entity,
                     label: relation.name,
-                    pathSelector: 'relation', // the CSS class for path
-                    labelSelector: 'relation-label', // the CSS class for label
+                    pathSelector: 'relation-selector', // the CSS class for path
+                    labelSelector: 'relation-selector', // the CSS class for label
                 };
             });
         }

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -806,6 +806,9 @@ export function D3Blueprint(container, options) {
             .attr('text-anchor', 'middle')
             .attr('font-family', 'monospace')
                 .insert('textPath')
+                .attr('class', 'relation-text') // `relation-text` class is required for styling effects
+                .attr('from', (d) => (d.source._id)) // `from` class is required for styling effects used along with `relation-text`
+                .attr('to', (d) => (d.target._id)) // `to` class is required for styling effects used along with `relation-text`
                 .attr('xlink:href', (d)=>('#' + d.source._id + '-' + d.target._id))
                 .attr('startOffset', '59%') // 59% roughly reflects `middle of the arch` minus `node radius`.
                 .html((d) => (' ' + d.label + ' '));
@@ -1114,15 +1117,19 @@ export function D3Blueprint(container, options) {
     function selectNode(id) {
         _svg.selectAll('.entity.selected').classed('selected', false);
         _svg.selectAll('.relation.highlight').classed('highlight', false);
+        _svg.selectAll('.relation-text.highlight').classed('highlight', false);
         _svg.select(`#entity-${id}`).classed('selected', true);
         _svg.selectAll(`.relation[from='${id}']`).classed('highlight', true);
         _svg.selectAll(`.relation[to='${id}']`).classed('highlight', true);
+        _svg.selectAll(`.relation-text[from='${id}']`).classed('highlight', true);
+        _svg.selectAll(`.relation-text[to='${id}']`).classed('highlight', true);
         return this;
     }
 
     function unselectNode() {
         _svg.selectAll('.entity.selected').classed('selected', false);
         _svg.selectAll('.relation.highlight').classed('highlight', false);
+        _svg.selectAll('.relation-text.highlight').classed('highlight', false);
         return this;
     }
 
@@ -1321,6 +1328,7 @@ export function D3Blueprint(container, options) {
             .filter(r => r.source.hasAncestor(node.data) || r.target.hasAncestor(node.data))
             .forEach(r => {
                 _relationGroup.selectAll(`.relation[from='${r.source._id}'][to='${r.target._id}']`).classed('hidden', true);
+                _relationGroup.selectAll(`.relation-text[from='${r.source._id}'][to='${r.target._id}']`).classed('hidden', true);
             });
     }
 
@@ -1329,6 +1337,7 @@ export function D3Blueprint(container, options) {
      */
     function showRelationships() {
         _relationGroup.selectAll('.relation').classed('hidden', false);
+        _relationGroup.selectAll('.relation-text').classed('hidden', false);
     }
 
     /**

--- a/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
+++ b/ui-modules/blueprint-composer/app/components/util/d3-blueprint.js
@@ -781,12 +781,11 @@ export function D3Blueprint(container, options) {
 
         // Draw the relationship path
         relationDataEntered.insert('path')
-            .attr('class', (d) => (d.pathSelector))
+            .attr('class', (d) => ('relation ' + d.pathSelector))
             .attr('id', (d)=>(d.source._id + '-' + d.target._id))
             .attr('opacity', 0)
             .attr('from', (d)=>(d.source._id))
             .attr('to', (d)=>(d.target._id));
-
 
         // Draw the relationship label that follows the path, somewhere in the middle.
         // NOTE `textPath` DECREASES THE UI PERFORMANCE, USE LABELS WITH CAUTION.

--- a/ui-modules/blueprint-composer/app/views/main/main.controller.js
+++ b/ui-modules/blueprint-composer/app/views/main/main.controller.js
@@ -50,7 +50,7 @@ export const LAYERS = [
     {
         id: 'relationships',
         label: 'Relationships',
-        selector: '.relation-group',
+        selector: '.relation-selector',
         active: true
     },
     {


### PR DESCRIPTION
Switch relationships with path and label selector rather than whole relationship group, relationships can belong to sub-groups to be managed separately

Signed-off-by: Mykola Mandra <mykola.mandra@cloudsoftcorp.com>