### PR TITLE
Add support for an ancestor quick fix

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -574,7 +574,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                             .group('config')
                             .ref(definition.name)
                             .level(ISSUE_LEVEL.WARN)
-                            .message(`Implicitly defined from one of it's ancestor`)
+                            .message(`Implicitly defined from one of its ancestor`)
                             .build());
                     }
                 });

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -566,7 +566,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
 
     function refreshConfigInherited(entity) {
         return $q((resolve) => {
-            entity.miscData.get('config')
+            (Array.isArray(entity.miscData.get('config')) ? entity.miscData.get('config') : [])
                 .filter(definition => !entity.config.has(definition.name))
                 .forEach(definition => {
                     if (entity.hasInheritedConfig(definition.name)) {

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -34,6 +34,14 @@ export default MODULE_NAME;
 export const RESERVED_KEYS = ['name', 'location', 'locations', 'type', 'services', 'brooklyn.config', 'brooklyn.children', 'brooklyn.enrichers', 'brooklyn.policies'];
 export const DSL_ENTITY_SPEC = '$brooklyn:entitySpec';
 
+export const COMMON_HINTS = {
+    'config-quick-fixes': [{
+        key: '.*',
+        fix: 'explicit_config',
+        'message-regex': /implicitly defined/i
+    }]
+};
+
 export function blueprintServiceProvider() {
     return {
         $get: ['$log', '$q', '$sce', 'paletteApi', 'iconGenerator', 'dslService', 'brBrandInfo',
@@ -126,6 +134,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
         refreshConfigConstraints: refreshConfigConstraints,
         refreshRelationships: refreshRelationships,
         refreshAllRelationships: refreshAllRelationships,
+        refreshConfigInherited: refreshConfigInherited,
         addRelationshipsProvider: addEntityRelationshipsProvider,
         isReservedKey: isReservedKey,
         getIssues: getIssues,
@@ -343,6 +352,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                 refreshConfigMemberspecsMetadata(entity),
                 refreshPoliciesMetadata(entity),
                 refreshEnrichersMetadata(entity),
+                refreshConfigInherited(entity)
             ]);
         }).then(()=> {
             return entity;
@@ -390,7 +400,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
         if (typeof location === 'object' && Object.keys(location).length==1) return Object.keys(location)[0];
         return null;
     }
-    
+
     function refreshLocationMetadata(entity) {
         let deferred = $q.defer();
 
@@ -554,6 +564,24 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
         }, []));
     }
 
+    function refreshConfigInherited(entity) {
+        return $q((resolve) => {
+            entity.miscData.get('config')
+                .filter(definition => !entity.config.has(definition.name))
+                .forEach(definition => {
+                    if (entity.hasInheritedConfig(definition.name)) {
+                        entity.addIssue(Issue.builder()
+                            .group('config')
+                            .ref(definition.name)
+                            .level(ISSUE_LEVEL.WARN)
+                            .message(`Implicitly defined from one of it's ancestor`)
+                            .build());
+                    }
+                });
+            resolve();
+        });
+    }
+
     function parseInput(input, entity) {
         return $q((resolve, reject) => {
             try {
@@ -713,11 +741,10 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
         entity.miscData.set('sensors', data.sensors || []);
         entity.miscData.set('traits', data.supertypes || []);
         entity.miscData.set('tags', data.tags || []);
-        var uiHints = {};
-        data.tags.forEach( (t) => { 
-            mergeAppendingLists(uiHints, t['ui-composer-hints']);
+        data.tags.forEach( (t) => {
+            mergeAppendingLists(COMMON_HINTS, t['ui-composer-hints']);
         });
-        entity.miscData.set('ui-composer-hints', uiHints);
+        entity.miscData.set('ui-composer-hints', COMMON_HINTS);
         entity.miscData.set('virtual', data.virtual || null);
         addUnlistedConfigKeysDefinitions(entity);
         addUnlistedParameterDefinitions(entity);
@@ -753,20 +780,20 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
     function populateLocationFromApiCommon(entity, data) {
         entity.clearIssues({group: 'location'});
         entity.location = data.yamlHere || data.symbolicName;
-        
+
         let name = data.name || data.displayName;
         if (!name && data.yamlHere) {
             name = typeof data.yamlHere === 'object' ? Object.keys(data.yamlHere)[0] : data.yamlHere;
         }
         if (!name) name =  data.symbolicName;
         entity.miscData.set('locationName', name);
-        
+
         // use icon on item, but if none then generate using *yaml* to distinguish when someone has changed it
         // (especially for things like jclouds:aws-ec2 -- the config is more interesting than the type name)
         entity.miscData.set('locationIcon', data==null ? null : data.iconUrl || iconGenerator(data.yamlHere ? JSON.stringify(data.yamlHere) : data.symbolicName));
         return entity;
     }
-    
+
     function populateLocationFromApiSuccess(entity, data) {
         populateLocationFromApiCommon(entity, data);
     }
@@ -841,12 +868,12 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
         let candidate = entity.hasName()
             ? entity.name.replace(/\W/g, '-').toLowerCase()
             : entity.type ? entity.type.replace(/\W/g, '-').toLowerCase()
-            : !entity.parent ? "root"
-            : entity._id;
+                : !entity.parent ? "root"
+                    : entity._id;
         return uniqueSuffixFn(
-                candidate,
-                entity.getApplication() /* unique throughout blueprint */,
-                null /* use default salter */ );
+            candidate,
+            entity.getApplication() /* unique throughout blueprint */,
+            null /* use default salter */ );
     }
 
 }

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -95,7 +95,7 @@ export const CONFIG_FILTERS = [
 export const PARAM_TYPES = [
     // cut-down list from BasicSpecParameter.ParseYamlInputs
     'string', 'boolean', 'integer', 'double', 'duration', ' port'
-    ];
+];
 
 export function specEditorDirective($rootScope, $templateCache, $injector, $sanitize, $filter, $log, $sce, $timeout, $document, $state, $compile, blueprintService, composerOverrides, mdHelper) {
     return {
@@ -271,6 +271,8 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             blueprintService.refreshRelationships(scope.model).then(() => {
                 return blueprintService.refreshConfigConstraints(scope.model);
             }).then(() => {
+                return blueprintService.refreshConfigInherited(scope.model);
+            }).then(() => {
                 refreshCustomValidation(scope.model);
             }).then(() => {
                 scope.model.issuesWithFixes = [];
@@ -368,7 +370,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         scope.nonempty = (o) => o && Object.keys(o).length;
         scope.defined = specEditor.defined = (o) => (typeof o !== 'undefined');
         specEditor.isInstance = (x, type) => (typeof x === type);
-                
+
         specEditor.advanceOutToFormGroupInPanel = (element, event) => {
             focusIfPossible(event, findAncestor(element, "form-group", "panel-body")) || element[0].blur();
         };
@@ -872,7 +874,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         function getConfig(name) {
             return scope.model.miscData.get('config').find(p => p.name === name);
         }
-        
+
 
         function loadCustomConfigWidgetMetadata(model) {
             let customConfigWidgets = (scope.model.miscData.get('ui-composer-hints') || {})['config-widgets'] || [];
@@ -1160,12 +1162,12 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             }
             if (oldName && oldName!==newName) {
                 scope.state.parameters.codeModeActive[newName] = scope.state.parameters.codeModeActive[oldName];
-                scope.state.parameters.codeModeError[newName] = scope.state.parameters.codeModeError[oldName]; 
-                delete scope.state.parameters.codeModeActive[oldName]; 
+                scope.state.parameters.codeModeError[newName] = scope.state.parameters.codeModeError[oldName];
+                delete scope.state.parameters.codeModeActive[oldName];
                 delete scope.state.parameters.codeModeError[oldName];
                 return true;
             }
-            return false;            
+            return false;
         }
         function setModelFromLocalParameters() {
             if (scope.state.parameters && scope.state.parameters.edit && scope.state.parameters.edit.item) {
@@ -1181,12 +1183,12 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                             Object.keys(item).forEach((k) => delete item[k]);
                             Object.assign(item, parsed);
                         }
-                        
+
                     } catch (e) {
                         // $log.warn("ERROR parsing json", scope.state.parameters.edit.json, e);
                         scope.state.parameters.edit.errors.push({ message: "Invalid JSON for parameter" });
                     }
-                    
+
                 } else {
                     if (scope.state.parameters.edit.newName) {
                         if (blueprintService.isReservedKey(scope.state.parameters.edit.newName)) {
@@ -1197,11 +1199,11 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                     } else {
                         scope.state.parameters.edit.errors.push({ message: "Key name must not be blank" });
                     }
-                     
+
                     try {
                         let c = scope.state.parameters.edit.constraints ? JSON.parse(scope.state.parameters.edit.constraints) : [];
                         if (Array.isArray(c)) {
-                            if (c.length==0) { 
+                            if (c.length==0) {
                                 delete item['constraints'];
                             } else {
                                 item.constraints = c;
@@ -1213,14 +1215,14 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                         $log.warn("ERROR parsing constraints", scope.state.parameters.edit.constraints, e);
                         scope.state.parameters.edit.errors.push({ message: "Invalid constraint JSON" });
                     }
-                    
+
                     // empty values are removed
                     if (item.description === '') {
                         delete item['description'];
-                    } 
+                    }
                     if (item.label === '') {
                         delete item['label'];
-                    } 
+                    }
                     if (item.default === '') {
                         if (scope.state.parameters.edit.original.default!=='') {
                             // don't delete if default was explicitly set in yaml as "";
@@ -1230,7 +1232,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                     }
                 }
             }
-            
+
             let localParams = scope.parameters;
             let result = [];
             for (let paramRef of localParams) {

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -288,11 +288,11 @@ export class Entity {
         LOCATIONS.delete(this);
         this.miscData.delete('locationName');
         this.miscData.delete('locationIcon');
-        
+
         // this field provides a way for consumers to detect if the location was explicitly removed;
         // this can be useful to prevent default locations from being applied
         this.miscData.set('locationRemoved', true);
-        
+
         this.touch();
     }
 
@@ -632,6 +632,7 @@ Entity.prototype.getClusterMemberspecEntity = getClusterMemberspecEntity;
 Entity.prototype.getClusterMemberspecEntities = getClusterMemberspecEntities;
 Entity.prototype.getInheritedLocation = getInheritedLocation;
 Entity.prototype.hasInheritedLocation = hasInheritedLocation;
+Entity.prototype.hasInheritedConfig = hasInheritedConfig;
 Entity.prototype.addIssue = addIssue;
 Entity.prototype.hasIssues = hasIssues;
 Entity.prototype.clearIssues = clearIssues;
@@ -803,8 +804,8 @@ function isCluster() {
     let traits = MISC_DATA.get(this).get('traits');
     return traits && traits.filter((trait)=> {
         return ['org.apache.brooklyn.entity.group.Cluster',
-                'org.apache.brooklyn.entity.group.Fabric']
-                .indexOf(trait) !== -1
+            'org.apache.brooklyn.entity.group.Fabric']
+            .indexOf(trait) !== -1
     }).length > 0;
 }
 
@@ -818,7 +819,7 @@ function isMemberSpec() {
 
 export function baseType(s) {
     if (s && s.indexOf("<")>=0) {
-        s = s.substring(0, s.indexOf("<")); 
+        s = s.substring(0, s.indexOf("<"));
     }
     return s;
 }
@@ -840,7 +841,7 @@ function getClusterMemberspecEntities() {
             return acc;
         }, {});
 }
-       
+
 /**
  * Returns the first memberspec that matches the given predicate
  *
@@ -956,6 +957,17 @@ function getInheritedLocation() {
  */
 function hasInheritedLocation() {
     return this.getInheritedLocation() !== null;
+}
+
+function hasInheritedConfig(key) {
+    if (this.hasParent()) {
+        let ret = false;
+        this.parent.visitWithAncestors(ancestor => {
+            ret = ret || ancestor.config.has(key);
+        });
+        return ret;
+    }
+    return false;
 }
 
 function addIssue(issue) {

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -55,24 +55,28 @@
                 <div ng-if="allIssues.errors.count">
                     <a class="hand" ng-click="errorsPane.level = 'error-errors'">
                         <ng-pluralize count="allIssues.errors.count"
-                                      when="{'one': '{} error', 'other': '{} errors'}" />
+                                      when="{'one': '{} error', 'other': '{} errors'}">
+                        </ng-pluralize>
                     </a>
                     in
                     <a class="hand" ng-click="errorsPane.level = 'error-entities'">
                         <ng-pluralize count="vm.size(allIssues.errors.byEntity)"
-                                      when="{'one': '{} entity', 'other': '{} entities'}" />
+                                      when="{'one': '{} entity', 'other': '{} entities'}">
+                        </ng-pluralize>
                     </a>
                 </div>
 
                 <div ng-if="allIssues.warnings.count">
                     <a class="hand" ng-click="errorsPane.level = 'warning-errors'">
                         <ng-pluralize count="allIssues.warnings.count"
-                                      when="{'one': '{} warning', 'other': '{} warnings'}" />
+                                      when="{'one': '{} warning', 'other': '{} warnings'}">
+                        </ng-pluralize>
                     </a>
                     in
                     <a class="hand" ng-click="errorsPane.level = 'warning-entities'">
                         <ng-pluralize count="vm.size(allIssues.warnings.byEntity)"
-                                      when="{'one': '{} entity', 'other': '{} entities'}" />
+                                      when="{'one': '{} entity', 'other': '{} entities'}">
+                        </ng-pluralize>
                     </a>
                 </div>
 
@@ -89,14 +93,16 @@
 
                 <strong>
                     <ng-pluralize count="vm.size(allIssues.errors.byEntity)"
-                                  when="{'one': '{} entity', 'other': '{} entities'}" />
+                                  when="{'one': '{} entity', 'other': '{} entities'}">
+                    </ng-pluralize>
                 </strong>
 
                 with
 
                 <a class="hand" ng-click="errorsPane.level = 'error-errors'">
                     <ng-pluralize count="allIssues.errors.count"
-                                  when="{'one': '{} error', 'other': '{} errors'}" />
+                                  when="{'one': '{} error', 'other': '{} errors'}">
+                    </ng-pluralize>
                 </a>
             </div>
 
@@ -133,7 +139,8 @@
 
                 <a class="hand" ng-click="errorsPane.level = 'error-entities'">
                     <ng-pluralize count="vm.size(allIssues.errors.byEntity)"
-                                  when="{'one': '{} entity', 'other': '{} entities'}" />
+                                  when="{'one': '{} entity', 'other': '{} entities'}">
+                    </ng-pluralize>
                 </a>
             </div>
 
@@ -155,13 +162,15 @@
                         (<a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'errors:'+itemK ? null : 'errors:'+itemK)"
                             ng-class="{active: errorsPane.focus == 'errors:'+itemK }">
                             <ng-pluralize count="itemV.issues.length"
-                                          when="{'one': '{} entity', 'other': '{} entities'}" />
+                                          when="{'one': '{} entity', 'other': '{} entities'}">
+                            </ng-pluralize>
                         </a>
                         <span ng-if="vm.size(itemV.quickFixes)">;
                           <a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'fixes:'+itemK ? null : 'fixes:'+itemK)"
                              ng-class="{active: errorsPane.focus == 'fixes:'+itemK }">
                              <ng-pluralize count="vm.size(itemV.quickFixes)"
-                                           when="{'one': '{} quick fix', 'other': '{} quick fixes'}" />
+                                           when="{'one': '{} quick fix', 'other': '{} quick fixes'}">
+                             </ng-pluralize>
                              available
                           </a>
                         </span>)
@@ -194,7 +203,8 @@
                                        ng-attr-title="{{ fix.tooltip }}"
                                     >Apply
                                         (<ng-pluralize count="vm.size(fix.issues)"
-                                                       when="{'one': '{} entity', 'other': '{} entities'}" />)
+                                                       when="{'one': '{} entity', 'other': '{} entities'}">
+                                        </ng-pluralize>)
                                     </a>
                                 </div>
                             </div>
@@ -217,14 +227,16 @@
 
                 <strong>
                     <ng-pluralize count="vm.size(allIssues.warnings.byEntity)"
-                                  when="{'one': '{} entity', 'other': '{} entities'}" />
+                                  when="{'one': '{} entity', 'other': '{} entities'}">
+                    </ng-pluralize>
                 </strong>
 
                 with
 
                 <a class="hand" ng-click="errorsPane.level = 'warning-errors'">
                     <ng-pluralize count="allIssues.warnings.count"
-                                  when="{'one': '{} warning', 'other': '{} warnings'}" />
+                                  when="{'one': '{} warning', 'other': '{} warnings'}">
+                    </ng-pluralize>
                 </a>
             </div>
 
@@ -252,7 +264,8 @@
 
                 <strong>
                     <ng-pluralize count="allIssues.warnings.count"
-                                  when="{'one': '{} warning', 'other': '{} warnings'}" />
+                                  when="{'one': '{} warning', 'other': '{} warnings'}">
+                    </ng-pluralize>
                 </strong>
 
                 <span ng-show="allIssues.warnings.count != vm.size(allIssues.warnings.byMessage)"> ({{ vm.size(allIssues.warnings.byMessage) }} unique)</span>
@@ -261,7 +274,8 @@
 
                 <a class="hand" ng-click="errorsPane.level = 'warning-entities'">
                     <ng-pluralize count="vm.size(allIssues.warnings.byEntity)"
-                                  when="{'one': '{} entity', 'other': '{} entities'}" />
+                                  when="{'one': '{} entity', 'other': '{} entities'}">
+                    </ng-pluralize>
                 </a>
             </div>
 
@@ -283,13 +297,15 @@
                         (<a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'warnings:'+itemK ? null : 'warnings:'+itemK)"
                             ng-class="{active: errorsPane.focus == 'warnings:'+itemK }">
                             <ng-pluralize count="itemV.issues.length"
-                                          when="{'one': '{} entity', 'other': '{} entities'}" />
+                                          when="{'one': '{} entity', 'other': '{} entities'}">
+                            </ng-pluralize>
                         </a>
                         <span ng-if="vm.size(itemV.quickFixes)">;
                           <a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'fixes:'+itemK ? null : 'fixes:'+itemK)"
                              ng-class="{active: errorsPane.focus == 'fixes:'+itemK }">
                              <ng-pluralize count="vm.size(itemV.quickFixes)"
-                                           when="{'one': '{} quick fix', 'other': '{} quick fixes'}" />
+                                           when="{'one': '{} quick fix', 'other': '{} quick fixes'}">
+                             </ng-pluralize>
                              available
                           </a>
                         </span>)
@@ -322,7 +338,8 @@
                                        ng-attr-title="{{ fix.tooltip }}"
                                     >Apply
                                         (<ng-pluralize count="vm.size(fix.issues)"
-                                                      when="{'one': '{} entity', 'other': '{} entities'}" />)
+                                                      when="{'one': '{} entity', 'other': '{} entities'}">
+                                        </ng-pluralize>)
                                     </a>
                                 </div>
                             </div>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -54,28 +54,25 @@
 
                 <div ng-if="allIssues.errors.count">
                     <a class="hand" ng-click="errorsPane.level = 'error-errors'">
-                        {{ allIssues.errors.count }}
-                        <span ng-if="allIssues.errors.count == 1">error</span>
-                        <span ng-if="allIssues.errors.count != 1">errors</span>
+                        <ng-pluralize count="allIssues.errors.count"
+                                      when="{'one': '{} error', 'other': '{} errors'}" />
                     </a>
                     in
                     <a class="hand" ng-click="errorsPane.level = 'error-entities'">
-                        {{ vm.size(allIssues.errors.byEntity) }}
-                        <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
-                        <span ng-if="vm.size(allIssues.errors.byEntity) != 1">entities</span>
+                        <ng-pluralize count="vm.size(allIssues.errors.byEntity)"
+                                      when="{'one': '{} entity', 'other': '{} entities'}" />
                     </a>
                 </div>
 
                 <div ng-if="allIssues.warnings.count">
                     <a class="hand" ng-click="errorsPane.level = 'warning-errors'">
-                        {{ allIssues.warnings.count }}
-                        <span ng-if="allIssues.errors.count == 1">warning</span>
-                        <span ng-if="allIssues.errors.count != 1">warnings</span>
+                        <ng-pluralize count="allIssues.warnings.count"
+                                      when="{'one': '{} warning', 'other': '{} warnings'}" />
                     </a>
+                    in
                     <a class="hand" ng-click="errorsPane.level = 'warning-entities'">
-                        in {{ vm.size(allIssues.warnings.byEntity) }}
-                        <span ng-if="vm.size(allIssues.warnings.byEntity) == 1">entity</span>
-                        <span ng-if="vm.size(allIssues.warnings.byEntity) != 1">entities</span>
+                        <ng-pluralize count="vm.size(allIssues.warnings.byEntity)"
+                                      when="{'one': '{} entity', 'other': '{} entities'}" />
                     </a>
                 </div>
 
@@ -90,16 +87,16 @@
             <div class="errorsHeader">
                 <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
 
-                <b>{{ vm.size(allIssues.errors.byEntity) }}
-                    <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
-                    <span ng-if="vm.size(allIssues.errors.byEntity) != 1">entities</span></b>
+                <strong>
+                    <ng-pluralize count="vm.size(allIssues.errors.byEntity)"
+                                  when="{'one': '{} entity', 'other': '{} entities'}" />
+                </strong>
 
                 with
 
                 <a class="hand" ng-click="errorsPane.level = 'error-errors'">
-                    {{ allIssues.errors.count }}
-                    <span ng-if="allIssues.errors.count == 1">error</span>
-                    <span ng-if="allIssues.errors.count != 1">errors</span>
+                    <ng-pluralize count="allIssues.errors.count"
+                                  when="{'one': '{} error', 'other': '{} errors'}" />
                 </a>
             </div>
 
@@ -125,17 +122,18 @@
             <div class="errorsHeader">
                 <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
 
-                <b>{{ allIssues.errors.count }}
-                    <span ng-if="allIssues.errors.count == 1">error</span>
-                    <span ng-if="allIssues.errors.count != 1">errors</span></b>
+                <strong>
+                    <ng-pluralize count="allIssues.errors.count"
+                                  when="{'one': '{} error', 'other': '{} errors'}" />
+                </strong>
+
                 <span ng-show="allIssues.errors.count != vm.size(allIssues.errors.byMessage)"> ({{ vm.size(allIssues.errors.byMessage) }} unique)</span>
 
                 in
 
                 <a class="hand" ng-click="errorsPane.level = 'error-entities'">
-                    {{ vm.size(allIssues.errors.byEntity) }}
-                    <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
-                    <span ng-if="vm.size(allIssues.errors.byEntity) != 1">entities</span>
+                    <ng-pluralize count="vm.size(allIssues.errors.byEntity)"
+                                  when="{'one': '{} entity', 'other': '{} entities'}" />
                 </a>
             </div>
 
@@ -155,13 +153,18 @@
                       </span>
 
                         (<a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'errors:'+itemK ? null : 'errors:'+itemK)"
-                            ng-class="{active: errorsPane.focus == 'errors:'+itemK }">{{
-                        itemV.issues.length }}
-                        {{ itemV.issues.length==1 ? 'entity' : 'entities'
-                        }}</a><span ng-if="vm.size(itemV.quickFixes)">;
+                            ng-class="{active: errorsPane.focus == 'errors:'+itemK }">
+                            <ng-pluralize count="itemV.issues.length"
+                                          when="{'one': '{} entity', 'other': '{} entities'}" />
+                        </a>
+                        <span ng-if="vm.size(itemV.quickFixes)">;
                           <a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'fixes:'+itemK ? null : 'fixes:'+itemK)"
                              ng-class="{active: errorsPane.focus == 'fixes:'+itemK }">
-                            {{ vm.size(itemV.quickFixes) }} quick fix<span ng-if="vm.size(itemV.quickFixes) != 1">es</span> available</a></span>)
+                             <ng-pluralize count="vm.size(itemV.quickFixes)"
+                                           when="{'one': '{} quick fix', 'other': '{} quick fixes'}" />
+                             available
+                          </a>
+                        </span>)
 
                         <div class="error-line-sub" ng-if="errorsPane.focus == 'errors:'+itemK">
                             <div ng-repeat="issue in itemV.issues" class="error-line-sub-line">
@@ -190,10 +193,8 @@
                                     <a class="hand btn btn-xs btn-primary" style="float: right;" ng-click="vm.applyQuickFix(fix)"
                                        ng-attr-title="{{ fix.tooltip }}"
                                     >Apply
-                                        ({{ vm.size(fix.issues) }}
-                                        <span ng-if="vm.size(fix.issues) == 1">entity</span
-                                        ><span ng-if="vm.size(fix.issues) != 1">entities</span
-                                        >)
+                                        (<ng-pluralize count="vm.size(fix.issues)"
+                                                       when="{'one': '{} entity', 'other': '{} entities'}" />)
                                     </a>
                                 </div>
                             </div>
@@ -214,21 +215,21 @@
             <div class="errorsHeader">
                 <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
 
-                <b>{{ vm.size(allIssues.warnings.byEntity) }}
-                    <span ng-if="vm.size(allIssues.warnings.byEntity) == 1">entity</span>
-                    <span ng-if="vm.size(allIssues.warnings.byEntity) != 1">entities</span></b>
+                <strong>
+                    <ng-pluralize count="vm.size(allIssues.warnings.byEntity)"
+                                  when="{'one': '{} entity', 'other': '{} entities'}" />
+                </strong>
 
                 with
 
                 <a class="hand" ng-click="errorsPane.level = 'warning-errors'">
-                    {{ allIssues.warnings.count }}
-                    <span ng-if="allIssues.warnings.count == 1">warning</span>
-                    <span ng-if="allIssues.warnings.count != 1">warnings</span>
+                    <ng-pluralize count="allIssues.warnings.count"
+                                  when="{'one': '{} warning', 'other': '{} warnings'}" />
                 </a>
             </div>
 
             <div class="errors-body">
-                <div ng-repeat="(itemK,itemV) in allIssues.warnings.byEntity" class="error-line">
+                <div ng-repeat="(itemK,itemV) in allIssues.warnings.byEntity" class="error-line warning">
                     <div class="error-line-marker">
                         <i class="fa fa-fw fa-times-circle"></i>
                     </div>
@@ -249,17 +250,18 @@
             <div class="errorsHeader">
                 <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
 
-                <b>{{ allIssues.warnings.count }}
-                    <span ng-if="allIssues.warnings.count == 1">warning</span>
-                    <span ng-if="allIssues.warnings.count != 1">warnings</span></b>
+                <strong>
+                    <ng-pluralize count="allIssues.warnings.count"
+                                  when="{'one': '{} warning', 'other': '{} warnings'}" />
+                </strong>
+
                 <span ng-show="allIssues.warnings.count != vm.size(allIssues.warnings.byMessage)"> ({{ vm.size(allIssues.warnings.byMessage) }} unique)</span>
 
                 in
 
                 <a class="hand" ng-click="errorsPane.level = 'warning-entities'">
-                    {{ vm.size(allIssues.warnings.byEntity) }}
-                    <span ng-if="vm.size(allIssues.warnings.byEntity) == 1">entity</span>
-                    <span ng-if="vm.size(allIssues.warnings.byEntity) != 1">entities</span>
+                    <ng-pluralize count="vm.size(allIssues.warnings.byEntity)"
+                                  when="{'one': '{} entity', 'other': '{} entities'}" />
                 </a>
             </div>
 
@@ -279,13 +281,18 @@
                       </span>
 
                         (<a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'warnings:'+itemK ? null : 'warnings:'+itemK)"
-                            ng-class="{active: errorsPane.focus == 'warnings:'+itemK }">{{
-                        itemV.issues.length }}
-                        {{ itemV.issues.length==1 ? 'entity' : 'entities'
-                        }}</a><span ng-if="vm.size(itemV.quickFixes)">;
+                            ng-class="{active: errorsPane.focus == 'warnings:'+itemK }">
+                            <ng-pluralize count="itemV.issues.length"
+                                          when="{'one': '{} entity', 'other': '{} entities'}" />
+                        </a>
+                        <span ng-if="vm.size(itemV.quickFixes)">;
                           <a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'fixes:'+itemK ? null : 'fixes:'+itemK)"
                              ng-class="{active: errorsPane.focus == 'fixes:'+itemK }">
-                            {{ vm.size(itemV.quickFixes) }} quick fix<span ng-if="vm.size(itemV.quickFixes) != 1">es</span> available</a></span>)
+                             <ng-pluralize count="vm.size(itemV.quickFixes)"
+                                           when="{'one': '{} quick fix', 'other': '{} quick fixes'}" />
+                             available
+                          </a>
+                        </span>)
 
                         <div class="error-line-sub" ng-if="errorsPane.focus == 'warnings:'+itemK">
                             <div ng-repeat="issue in itemV.issues" class="error-line-sub-line">
@@ -314,10 +321,8 @@
                                     <a class="hand btn btn-xs btn-primary" style="float: right;" ng-click="vm.applyQuickFix(fix)"
                                        ng-attr-title="{{ fix.tooltip }}"
                                     >Apply
-                                        ({{ vm.size(fix.issues) }}
-                                        <span ng-if="vm.size(fix.issues) == 1">entity</span
-                                        ><span ng-if="vm.size(fix.issues) != 1">entities</span
-                                        >)
+                                        (<ng-pluralize count="vm.size(fix.issues)"
+                                                      when="{'one': '{} entity', 'other': '{} entities'}" />)
                                     </a>
                                 </div>
                             </div>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.html
@@ -19,46 +19,119 @@
 
 <div class="palette-and-or-toolbar">
 
-  <div class="layout">
-    <div class="toolbar">
-        <div class="list-group">
-            <a class="hand list-group-item"
-               ng-repeat="section in vm.sections track by $index"
-               ng-class="{'active': vm.selectedSection === section}"
-               ng-click="vm.selectedSection = section">
-                <i class="fa fa-fw" ng-class="section.icon"></i>
-            </a>
+    <div class="layout">
+        <div class="toolbar">
+            <div class="list-group">
+                <a class="hand list-group-item"
+                   ng-repeat="section in vm.sections track by $index"
+                   ng-class="{'active': vm.selectedSection === section}"
+                   ng-click="vm.selectedSection = section">
+                    <i class="fa fa-fw" ng-class="section.icon"></i>
+                </a>
 
-            <div class="spacer"></div>
-            <a class="hand list-group-item errors-square"
-               title="Click to show/hide details of errors"
-               ng-class="{ errorsActive: errorsPane.level }"
-               ng-show="allIssues.errors.count"
-               ng-click="errorsPane.level = errorsPane.level ? null : 'error-errors'">
-                <i class="fa fa-fw fa-times-circle"></i> {{ allIssues.errors.count }}
-            </a>
-            <a class="hand list-group-item warning-square"
-               title="Click to show/hide details of warnings"
-               ng-class="{ errorsActive: errorsPane.level }"
-               ng-show="!allIssues.errors.count && allIssues.warnings.count"
-               ng-click="errorsPane.level = errorsPane.level ? null : 'summary'">
-                <i class="fa fa-fw fa-exclamation-triangle"></i> {{ allIssues.warnings.count }}
-            </a>
+                <div class="spacer"></div>
+                <a class="hand list-group-item errors-square"
+                   title="Click to show/hide details of errors"
+                   ng-class="{ errorsActive: errorsPane.level }"
+                   ng-show="allIssues.errors.count"
+                   ng-click="errorsPane.level = errorsPane.level ? null : 'error-errors'">
+                    <i class="fa fa-fw fa-times-circle"></i> {{ allIssues.errors.count }}
+                </a>
+                <a class="hand list-group-item warning-square"
+                   title="Click to show/hide details of warnings"
+                   ng-class="{ errorsActive: errorsPane.level }"
+                   ng-show="!allIssues.errors.count && allIssues.warnings.count"
+                   ng-click="errorsPane.level = errorsPane.level ? null : 'summary'">
+                    <i class="fa fa-fw fa-exclamation-triangle"></i> {{ allIssues.warnings.count }}
+                </a>
+            </div>
         </div>
-    </div>
 
-      <div ng-if="errorsPane.level == 'summary'" class="errors-popout">
-          <div class="errors-body">
+        <div ng-if="errorsPane.level == 'summary'" class="errors-popout">
+            <div class="errors-body">
 
-              <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
+                <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
 
-            <div ng-if="allIssues.errors.count">
+                <div ng-if="allIssues.errors.count">
+                    <a class="hand" ng-click="errorsPane.level = 'error-errors'">
+                        {{ allIssues.errors.count }}
+                        <span ng-if="allIssues.errors.count == 1">error</span>
+                        <span ng-if="allIssues.errors.count != 1">errors</span>
+                    </a>
+                    in
+                    <a class="hand" ng-click="errorsPane.level = 'error-entities'">
+                        {{ vm.size(allIssues.errors.byEntity) }}
+                        <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
+                        <span ng-if="vm.size(allIssues.errors.byEntity) != 1">entities</span>
+                    </a>
+                </div>
+
+                <div ng-if="allIssues.warnings.count">
+                    <a class="hand" ng-click="errorsPane.level = 'warning-errors'">
+                        {{ allIssues.warnings.count }}
+                        <span ng-if="allIssues.errors.count == 1">warning</span>
+                        <span ng-if="allIssues.errors.count != 1">warnings</span>
+                    </a>
+                    <a class="hand" ng-click="errorsPane.level = 'warning-entities'">
+                        in {{ vm.size(allIssues.warnings.byEntity) }}
+                        <span ng-if="vm.size(allIssues.warnings.byEntity) == 1">entity</span>
+                        <span ng-if="vm.size(allIssues.warnings.byEntity) != 1">entities</span>
+                    </a>
+                </div>
+
+                <div ng-if="!allIssues.errors.count && !allIssues.warnings.count">
+                    No errors or warnings.
+                </div>
+
+            </div>
+        </div>
+
+        <div ng-if="errorsPane.level == 'error-entities'" class="errors-popout">
+            <div class="errorsHeader">
+                <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
+
+                <b>{{ vm.size(allIssues.errors.byEntity) }}
+                    <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
+                    <span ng-if="vm.size(allIssues.errors.byEntity) != 1">entities</span></b>
+
+                with
+
                 <a class="hand" ng-click="errorsPane.level = 'error-errors'">
-                {{ allIssues.errors.count }}
+                    {{ allIssues.errors.count }}
                     <span ng-if="allIssues.errors.count == 1">error</span>
                     <span ng-if="allIssues.errors.count != 1">errors</span>
                 </a>
+            </div>
+
+            <div class="errors-body">
+                <div ng-repeat="(itemK,itemV) in allIssues.errors.byEntity" class="error-line">
+                    <div class="error-line-marker">
+                        <i class="fa fa-fw fa-times-circle"></i>
+                    </div>
+                    <div class="error-line-text">
+                        {{ vm.entitySummary(allIssues.entities[itemK]) }}:
+                        {{ itemV.length }} {{ itemV.length==1 ? 'error' : 'errors' }}
+                    </div>
+                    <div class="error-line-action">
+                        <a class="hand" ui-sref="main.graphical.edit.entity({entityId: itemK})">
+                            <i class="fa fa-fw fa-external-link"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div ng-if="errorsPane.level == 'error-errors'" class="errors-popout">
+            <div class="errorsHeader">
+                <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
+
+                <b>{{ allIssues.errors.count }}
+                    <span ng-if="allIssues.errors.count == 1">error</span>
+                    <span ng-if="allIssues.errors.count != 1">errors</span></b>
+                <span ng-show="allIssues.errors.count != vm.size(allIssues.errors.byMessage)"> ({{ vm.size(allIssues.errors.byMessage) }} unique)</span>
+
                 in
+
                 <a class="hand" ng-click="errorsPane.level = 'error-entities'">
                     {{ vm.size(allIssues.errors.byEntity) }}
                     <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
@@ -66,82 +139,12 @@
                 </a>
             </div>
 
-            <!-- TODO add links and panels for warnings -->
-            <div ng-if="allIssues.warnings.count">
-                {{ allIssues.warnings.count }}
-                    <span ng-if="allIssues.errors.count == 1">warning</span>
-                    <span ng-if="allIssues.errors.count != 1">warnings</span>
-                in {{ vm.size(allIssues.warnings.byEntity) }}
-                    <span ng-if="vm.size(allIssues.warnings.byEntity) == 1">entity</span>
-                    <span ng-if="vm.size(allIssues.warnings.byEntity) != 1">entities</span>
-            </div>
-
-            <div ng-if="!allIssues.errors.count && !allIssues.warnings.count">
-                No errors or warnings.
-            </div>
-
-          </div>
-      </div>
-
-      <div ng-if="errorsPane.level == 'error-entities'" class="errors-popout">
-          <div class="errorsHeader">
-              <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
-
-              <b>{{ vm.size(allIssues.errors.byEntity) }}
-                  <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
-                  <span ng-if="vm.size(allIssues.errors.byEntity) != 1">entities</span></b>
-
-              with
-
-              <a class="hand" ng-click="errorsPane.level = 'error-errors'">
-                  {{ allIssues.errors.count }}
-                  <span ng-if="allIssues.errors.count == 1">error</span>
-                  <span ng-if="allIssues.errors.count != 1">errors</span>
-              </a>
-          </div>
-
-          <div class="errors-body">
-            <div ng-repeat="(itemK,itemV) in allIssues.errors.byEntity" class="error-line">
-                <div class="error-line-marker">
-                    <i class="fa fa-fw fa-times-circle"></i>
-                </div>
-                <div class="error-line-text">
-                    {{ vm.entitySummary(allIssues.entities[itemK]) }}:
-                    {{ itemV.length }} {{ itemV.length==1 ? 'error' : 'errors' }}
-                </div>
-                <div class="error-line-action">
-                    <a class="hand" ui-sref="main.graphical.edit.entity({entityId: itemK})">
-                        <i class="fa fa-fw fa-external-link"></i>
-                    </a>
-                </div>
-            </div>
-          </div>
-      </div>
-
-      <div ng-if="errorsPane.level == 'error-errors'" class="errors-popout">
-          <div class="errorsHeader">
-              <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
-
-              <b>{{ allIssues.errors.count }}
-                  <span ng-if="allIssues.errors.count == 1">error</span>
-                  <span ng-if="allIssues.errors.count != 1">errors</span></b>
-              <span ng-show="allIssues.errors.count != vm.size(allIssues.errors.byMessage)"> ({{ vm.size(allIssues.errors.byMessage) }} unique)</span>
-
-              in
-
-              <a class="hand" ng-click="errorsPane.level = 'error-entities'">
-                  {{ vm.size(allIssues.errors.byEntity) }}
-                  <span ng-if="vm.size(allIssues.errors.byEntity) == 1">entity</span>
-                  <span ng-if="vm.size(allIssues.errors.byEntity) != 1">entities</span>
-              </a>
-          </div>
-
-          <div class="errors-body">
-              <div ng-repeat="(itemK,itemV) in allIssues.errors.byMessage" class="error-line">
-                  <div class="error-line-marker">
-                      <i class="fa fa-fw fa-times-circle"></i>
-                  </div>
-                  <div class="error-line-text">
+            <div class="errors-body">
+                <div ng-repeat="(itemK,itemV) in allIssues.errors.byMessage" class="error-line">
+                    <div class="error-line-marker">
+                        <i class="fa fa-fw fa-times-circle"></i>
+                    </div>
+                    <div class="error-line-text">
                       <span>
                           <span ng-show="vm.messageNeedsPrefix(itemV)">
                               {{ itemV.group }} {{ itemV.ref }}<span ng-show="itemV.message">:</span>
@@ -151,81 +154,205 @@
                           </span>
                       </span>
 
-                      (<a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'errors:'+itemK ? null : 'errors:'+itemK)"
+                        (<a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'errors:'+itemK ? null : 'errors:'+itemK)"
                             ng-class="{active: errorsPane.focus == 'errors:'+itemK }">{{
-                           itemV.issues.length }}
+                        itemV.issues.length }}
                         {{ itemV.issues.length==1 ? 'entity' : 'entities'
-                      }}</a><span ng-if="vm.size(itemV.quickFixes)">;
+                        }}</a><span ng-if="vm.size(itemV.quickFixes)">;
                           <a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'fixes:'+itemK ? null : 'fixes:'+itemK)"
-                                ng-class="{active: errorsPane.focus == 'fixes:'+itemK }">
+                             ng-class="{active: errorsPane.focus == 'fixes:'+itemK }">
                             {{ vm.size(itemV.quickFixes) }} quick fix<span ng-if="vm.size(itemV.quickFixes) != 1">es</span> available</a></span>)
 
-                      <div class="error-line-sub" ng-if="errorsPane.focus == 'errors:'+itemK">
-                          <div ng-repeat="issue in itemV.issues" class="error-line-sub-line">
-                              <div class="error-line-marker">
-                                  <i class="fa fa-fw fa-circle"></i>
-                              </div>
-                              <div class="error-line-text">
-                                  {{ vm.entitySummary(issue.issue.entity) }}
-                                  <!-- could offer the issue-specific quick fixes; but clearer to navigate to entity and do there -->
-                              </div>
-                              <div class="error-line-action">
-                                  <a class="hand" ui-sref="main.graphical.edit.entity({entityId: issue.issue.entity._id})">
-                                      <i class="fa fa-fw fa-external-link"></i>
-                                  </a>
-                              </div>
-                          </div>
-                      </div>
+                        <div class="error-line-sub" ng-if="errorsPane.focus == 'errors:'+itemK">
+                            <div ng-repeat="issue in itemV.issues" class="error-line-sub-line">
+                                <div class="error-line-marker">
+                                    <i class="fa fa-fw fa-circle"></i>
+                                </div>
+                                <div class="error-line-text">
+                                    {{ vm.entitySummary(issue.issue.entity) }}
+                                    <!-- could offer the issue-specific quick fixes; but clearer to navigate to entity and do there -->
+                                </div>
+                                <div class="error-line-action">
+                                    <a class="hand" ui-sref="main.graphical.edit.entity({entityId: issue.issue.entity._id})">
+                                        <i class="fa fa-fw fa-external-link"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
 
-                      <div class="error-line-sub" ng-if="errorsPane.focus == 'fixes:'+itemK">
-                          <div ng-repeat="fix in itemV.quickFixes" class="error-line-sub-line">
-                              <div class="error-line-marker">
-                                  <i class="fa fa-fw fa-magic"></i>
-                              </div>
-                              <div class="error-line-text">
-                                  {{ fix.text }}
-                                  <a class="hand btn btn-xs btn-primary" style="float: right;" ng-click="vm.applyQuickFix(fix)"
-                                     ng-attr-title="{{ fix.tooltip }}"
+                        <div class="error-line-sub" ng-if="errorsPane.focus == 'fixes:'+itemK">
+                            <div ng-repeat="fix in itemV.quickFixes" class="error-line-sub-line">
+                                <div class="error-line-marker">
+                                    <i class="fa fa-fw fa-magic"></i>
+                                </div>
+                                <div class="error-line-text">
+                                    {{ fix.text }}
+                                    <a class="hand btn btn-xs btn-primary" style="float: right;" ng-click="vm.applyQuickFix(fix)"
+                                       ng-attr-title="{{ fix.tooltip }}"
                                     >Apply
-                                      ({{ vm.size(fix.issues) }}
-                                      <span ng-if="vm.size(fix.issues) == 1">entity</span
-                                      ><span ng-if="vm.size(fix.issues) != 1">entities</span
-                                      >)
-                                  </a>
-                              </div>
-                          </div>
-                      </div>
-                  </div>
-                  <!--
-                  <div class="error-line-action">
-                      <a class="hand" ui-sref="main.graphical.edit.entity({entityId: itemK})">
-                          <i class="fa fa-fw fa-external-link"></i>
-                      </a>
-                  </div>
-                  -->
-              </div>
-          </div>
-      </div>
-
-    <designer on-selection-change="vm.onCanvasSelection"></designer>
-  </div>
-
-  <div class="pane pane-palette" ng-if="vm.selectedSection">
-    <div ng-repeat="section in vm.sections track by $index"
-         class="palette-full-height-wrapper"
-         ng-if="vm.selectedSection === section">
-        <div class="container-fluid palette-title">
-            <h3>
-                {{section.title}}
-                <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
-            </h3>
+                                        ({{ vm.size(fix.issues) }}
+                                        <span ng-if="vm.size(fix.issues) == 1">entity</span
+                                        ><span ng-if="vm.size(fix.issues) != 1">entities</span
+                                        >)
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!--
+                    <div class="error-line-action">
+                        <a class="hand" ui-sref="main.graphical.edit.entity({entityId: itemK})">
+                            <i class="fa fa-fw fa-external-link"></i>
+                        </a>
+                    </div>
+                    -->
+                </div>
+            </div>
         </div>
-        <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.addSelectedTypeToTargetEntity(item)" on-select-text="vm.getOnSelectText()" class="palette-full-height-wrapper"></catalog-selector>
-    </div>
-  </div>
 
-  <div class="pane pane-configuration">
-    <ui-view></ui-view>
-  </div>
+        <div ng-if="errorsPane.level == 'warning-entities'" class="errors-popout">
+            <div class="errorsHeader">
+                <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
+
+                <b>{{ vm.size(allIssues.warnings.byEntity) }}
+                    <span ng-if="vm.size(allIssues.warnings.byEntity) == 1">entity</span>
+                    <span ng-if="vm.size(allIssues.warnings.byEntity) != 1">entities</span></b>
+
+                with
+
+                <a class="hand" ng-click="errorsPane.level = 'warning-errors'">
+                    {{ allIssues.warnings.count }}
+                    <span ng-if="allIssues.warnings.count == 1">warning</span>
+                    <span ng-if="allIssues.warnings.count != 1">warnings</span>
+                </a>
+            </div>
+
+            <div class="errors-body">
+                <div ng-repeat="(itemK,itemV) in allIssues.warnings.byEntity" class="error-line">
+                    <div class="error-line-marker">
+                        <i class="fa fa-fw fa-times-circle"></i>
+                    </div>
+                    <div class="error-line-text">
+                        {{ vm.entitySummary(allIssues.entities[itemK]) }}:
+                        {{ itemV.length }} {{ itemV.length==1 ? 'warning' : 'warnings' }}
+                    </div>
+                    <div class="error-line-action">
+                        <a class="hand" ui-sref="main.graphical.edit.entity({entityId: itemK})">
+                            <i class="fa fa-fw fa-external-link"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div ng-if="errorsPane.level == 'warning-errors'" class="errors-popout">
+            <div class="errorsHeader">
+                <a ng-click="errorsPane.level = null" class="hand errors-close"><i class="fa fa-fw fa-times"></i></a>
+
+                <b>{{ allIssues.warnings.count }}
+                    <span ng-if="allIssues.warnings.count == 1">warning</span>
+                    <span ng-if="allIssues.warnings.count != 1">warnings</span></b>
+                <span ng-show="allIssues.warnings.count != vm.size(allIssues.warnings.byMessage)"> ({{ vm.size(allIssues.warnings.byMessage) }} unique)</span>
+
+                in
+
+                <a class="hand" ng-click="errorsPane.level = 'warning-entities'">
+                    {{ vm.size(allIssues.warnings.byEntity) }}
+                    <span ng-if="vm.size(allIssues.warnings.byEntity) == 1">entity</span>
+                    <span ng-if="vm.size(allIssues.warnings.byEntity) != 1">entities</span>
+                </a>
+            </div>
+
+            <div class="errors-body">
+                <div ng-repeat="(itemK,itemV) in allIssues.warnings.byMessage" class="error-line warning">
+                    <div class="error-line-marker">
+                        <i class="fa fa-fw fa-times-circle"></i>
+                    </div>
+                    <div class="error-line-text">
+                      <span>
+                          <span ng-show="vm.messageNeedsPrefix(itemV)">
+                              {{ itemV.group }} {{ itemV.ref }}<span ng-show="itemV.message">:</span>
+                          </span>
+                          <span ng-show="itemV.message">
+                              <ng-bind-html ng-bind-html="itemV.message"></ng-bind-html>
+                          </span>
+                      </span>
+
+                        (<a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'warnings:'+itemK ? null : 'warnings:'+itemK)"
+                            ng-class="{active: errorsPane.focus == 'warnings:'+itemK }">{{
+                        itemV.issues.length }}
+                        {{ itemV.issues.length==1 ? 'entity' : 'entities'
+                        }}</a><span ng-if="vm.size(itemV.quickFixes)">;
+                          <a class="hand" ng-click="errorsPane.focus = (errorsPane.focus == 'fixes:'+itemK ? null : 'fixes:'+itemK)"
+                             ng-class="{active: errorsPane.focus == 'fixes:'+itemK }">
+                            {{ vm.size(itemV.quickFixes) }} quick fix<span ng-if="vm.size(itemV.quickFixes) != 1">es</span> available</a></span>)
+
+                        <div class="error-line-sub" ng-if="errorsPane.focus == 'warnings:'+itemK">
+                            <div ng-repeat="issue in itemV.issues" class="error-line-sub-line">
+                                <div class="error-line-marker">
+                                    <i class="fa fa-fw fa-circle"></i>
+                                </div>
+                                <div class="error-line-text">
+                                    {{ vm.entitySummary(issue.issue.entity) }}
+                                    <!-- could offer the issue-specific quick fixes; but clearer to navigate to entity and do there -->
+                                </div>
+                                <div class="error-line-action">
+                                    <a class="hand" ui-sref="main.graphical.edit.entity({entityId: issue.issue.entity._id})">
+                                        <i class="fa fa-fw fa-external-link"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="error-line-sub" ng-if="errorsPane.focus == 'fixes:'+itemK">
+                            <div ng-repeat="fix in itemV.quickFixes" class="error-line-sub-line">
+                                <div class="error-line-marker">
+                                    <i class="fa fa-fw fa-magic"></i>
+                                </div>
+                                <div class="error-line-text">
+                                    {{ fix.text }}
+                                    <a class="hand btn btn-xs btn-primary" style="float: right;" ng-click="vm.applyQuickFix(fix)"
+                                       ng-attr-title="{{ fix.tooltip }}"
+                                    >Apply
+                                        ({{ vm.size(fix.issues) }}
+                                        <span ng-if="vm.size(fix.issues) == 1">entity</span
+                                        ><span ng-if="vm.size(fix.issues) != 1">entities</span
+                                        >)
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!--
+                    <div class="error-line-action">
+                        <a class="hand" ui-sref="main.graphical.edit.entity({entityId: itemK})">
+                            <i class="fa fa-fw fa-external-link"></i>
+                        </a>
+                    </div>
+                    -->
+                </div>
+            </div>
+        </div>
+
+        <designer on-selection-change="vm.onCanvasSelection"></designer>
+    </div>
+
+    <div class="pane pane-palette" ng-if="vm.selectedSection">
+        <div ng-repeat="section in vm.sections track by $index"
+             class="palette-full-height-wrapper"
+             ng-if="vm.selectedSection === section">
+            <div class="container-fluid palette-title">
+                <h3>
+                    {{section.title}}
+                    <br-svg type="close" class="pull-right" ng-click="vm.selectedSection = undefined"></br-svg>
+                </h3>
+            </div>
+            <catalog-selector state="paletteState" family="section.type" mode="{{ section.mode }}" on-select="vm.addSelectedTypeToTargetEntity(item)" on-select-text="vm.getOnSelectText()" class="palette-full-height-wrapper"></catalog-selector>
+        </div>
+    </div>
+
+    <div class="pane pane-configuration">
+        <ui-view></ui-view>
+    </div>
 
 </div>

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -157,6 +157,10 @@
         margin-top: 6px;
       }
     }
+
+    &.warning .error-line-marker {
+      color: @brand-warning;
+    }
   }
 
   #palette-controls-button {
@@ -170,23 +174,23 @@
     margin-top: -5px;
     padding: 12px 5px 4px 5px;
     display: flex;
-    
+
     .filters {
-        flex: 1 1 auto;
-        overflow: hidden;
-        display: flex;
-        flex-wrap: wrap;
-        
-        max-height: 27px;  // if things wrap hide them
-        &.multiline {      // unless toggled multiline
-            max-height: max-content; 
-        }
-        
-        .spacer {
-            flex: 0 0.5 1ex;
-        }
+      flex: 1 1 auto;
+      overflow: hidden;
+      display: flex;
+      flex-wrap: wrap;
+
+      max-height: 27px;  // if things wrap hide them
+      &.multiline {      // unless toggled multiline
+        max-height: max-content;
+      }
+
+      .spacer {
+        flex: 0 0.5 1ex;
+      }
     }
-    
+
     .nav-row-item {
       color: @gray-light;
       flex: 0 0 auto;
@@ -197,26 +201,26 @@
       cursor: hand;
     }
     .nav-row-item:hover {
-        color: @brand-primary;
+      color: @brand-primary;
     }
     span[uib-dropdown] {
-        align-self: start;
+      align-self: start;
     }
 
     a[aria-expanded="true"] {
-        > div.nav-row-item {
-            color: @brand-primary;
-        }
+      > div.nav-row-item {
+        color: @brand-primary;
+      }
     }
-    
+
     .spacer {
-        flex: 1 1 2em;
+      flex: 1 1 2em;
     }
-    
+
     .right-align-icon {
-        position: absolute;
-        left: auto;
-        right: 0;
+      position: absolute;
+      left: auto;
+      right: 0;
     }
   }
 }
@@ -237,9 +241,9 @@
     min-height: 400px; // should be enough to show a few rows, to allow pagination
 
     .palette-title {
-        margin-left: 0;
-        margin-right: 0;
-    }    
+      margin-left: 0;
+      margin-right: 0;
+    }
 
     .palette-spacer {
       max-height: 12px;
@@ -258,7 +262,7 @@
       margin-left: 0;
       margin-right: 0;
     }
-    
+
     h3 {
       color: @gray-light;
     }
@@ -279,33 +283,33 @@
     }
 
     .pane-palette .container-fluid {
-        padding-left: 15px;
-        padding-right: 15px;
+      padding-left: 15px;
+      padding-right: 15px;
     }
-    
+
     .container-fluid {
       padding: 0;
     }
 
     .add-panel {
+      display: flex;
+      flex-direction: column;
+      > .spec-parent {
+        flex: 0 0 auto;
+      }
+      > .add-panel-main {
+        flex: 1 1 auto;
         display: flex;
-        flex-direction: column;
-        > .spec-parent {
-            flex: 0 0 auto;
-        } 
-        > .add-panel-main {
-            flex: 1 1 auto;
-            display: flex;
-            flex-direction: row;
-            .toolbar {
-                flex: 0 0 auto;
-            }
-            .pane-palette {
-                flex: 1 1 auto;
-            }
+        flex-direction: row;
+        .toolbar {
+          flex: 0 0 auto;
         }
+        .pane-palette {
+          flex: 1 1 auto;
+        }
+      }
     }
-    
+
     .spec-parent {
       a {
         background-color: @gray-lighter;


### PR DESCRIPTION
This will check if an entity has implicit inherited config keys. If this is the case, then warnings will be created for these config keys. Additionally, a quick fix will be available to automatically set the implicit inherited config key `x` to `$brooklyn:parent().config("x")`

Here it is in action:
![quick-fix-ancestor](https://user-images.githubusercontent.com/2082759/124912966-7b5b8680-dfe6-11eb-964b-eccd8480bbb6.gif)
