### PR TITLE
Display deployment metadata on the entity popover in App Inspector

### DIFF
--- a/ui-modules/app-inspector/app/components/entity-tree/entity-node.html
+++ b/ui-modules/app-inspector/app/components/entity-tree/entity-node.html
@@ -60,6 +60,17 @@
                 <td><b>Number of children</b></td>
                 <td>{{nodesInCurrentView()}}</td>
             </tr>
+            <tr ng-repeat="(key, value) in (entity.sensors && entity.sensors['deployment.metadata']) || [] track by key">
+                <td ng-switch="key">
+                    <strong ng-switch-when="user">Deployed by</strong>
+                    <strong ng-switch-when="deploy_time">Deployed at</strong>
+                    <strong ng-switch-default>{{key}}</strong>
+                </td>
+                <td ng-switch="key">
+                    <span ng-switch-when="deploy_time">{{value | timeAgoFilter}}</span>
+                    <span ng-switch-default>{{value}}</span>
+                </td>
+            </tr>
         </table>
     </script>
 </div>

--- a/ui-modules/app-inspector/app/components/entity-tree/entity-tree.directive.js
+++ b/ui-modules/app-inspector/app/components/entity-tree/entity-tree.directive.js
@@ -60,7 +60,9 @@ export function entityTreeDirective() {
 
         let observers = [];
 
-        applicationApi.applicationsTree().then((response)=> {
+        applicationApi.applicationsTree({
+            sensors: 'deployment.metadata'
+        }).then((response)=> {
             vm.applications = response.data;
             analyzeRelationships(vm.applications);
 

--- a/ui-modules/app-inspector/app/components/providers/application-api.provider.js
+++ b/ui-modules/app-inspector/app/components/providers/application-api.provider.js
@@ -41,8 +41,8 @@ function ApplicationApi($http) {
     function getApplications() {
         return $http.get('/v1/applications', {observable: true, ignoreLoadingBar: true});
     }
-    function getApplicationsTree() {
-        return $http.get('/v1/applications/fetch', {observable: true, ignoreLoadingBar: true});
+    function getApplicationsTree(opts = {}) {
+        return $http.get('/v1/applications/fetch', {params: opts, observable: true, ignoreLoadingBar: true});
     }
     function getApplication(applicationId) {
         return $http.get('/v1/applications/' + applicationId, {observable: true, ignoreLoadingBar: true});


### PR DESCRIPTION
This requires:
- https://github.com/apache/brooklyn-server/pull/1200
- https://github.com/apache/brooklyn-dist/pull/174

Extract the deployment metadata and display that onto the entity popover in App Inspector:

![Screenshot 2021-07-15 at 09 36 41](https://user-images.githubusercontent.com/2082759/125757868-91d6342c-fd04-4dc4-858f-3915afbdb228.png)

