### PR TITLE
Make the timeAgoFilter stateful so it keeps updating the display

### DIFF
--- a/ui-modules/app-inspector/app/components/task-list/task-list.directive.js
+++ b/ui-modules/app-inspector/app/components/task-list/task-list.directive.js
@@ -84,11 +84,15 @@ export function taskListDirective() {
 }
 
 export function timeAgoFilter() {
-    return function (input) {
+    function timeAgo(input) {
         if (input) {
             return moment(input).fromNow();
         }
     }
+
+    timeAgo.$stateful = true;
+
+    return timeAgo;
 }
 export function durationFilter() {
     return function (input) {


### PR DESCRIPTION
By default, AngularJS does not reevalute an expression if the left part doesn't change. This is exactly what happens with the `timeAgoFilter`: the timestamp never changes obviously and therefore, the display keeps displaying the evaluated value at the moment of the first page display.

Marking the filter as `stateful` forces AngularJS to reevaluate when the scope changes.

By doing this, the task list (App Inspector) now updates the started time column on the fly