### PR TITLE
fix for scrollbars appearing in composer confirmation frame

### DIFF
--- a/ui-modules/blueprint-composer/app/components/designer/designer.less
+++ b/ui-modules/blueprint-composer/app/components/designer/designer.less
@@ -259,7 +259,7 @@ designer {
             align-items: center;
             background: lighten(@brand-primary, 50%);
             .node-confirmation-text {
-                overflow: scroll;
+                overflow: auto; // removes needless scrollbars
                 width: 90%;
             }
             .node-confirmation-button {


### PR DESCRIPTION
This addresses an issue on Windows browsers where the confirmation frame of the composer has scrollbars when it shouldn't.

