### PR TITLE
YAML editor renamed to CAMP editor

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
@@ -209,7 +209,7 @@ export function CatalogItemModalController($scope, $filter, blueprintService, pa
             itemType: $scope.config.itemType,
             item: blueprint
         };
-        // tags can now be added to a blueprint created in the YAML Editor
+        // tags can now be added to a blueprint created in the CAMP Editor
         let tags = [];
         if(blueprint.tags) {
             tags = blueprint.tags;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -1030,7 +1030,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 }
                 if (val.match(/^[0-9]*\.([0-9]*0)?$/)) {
                     // if user enters "3.0" or "1." we should treat it as a string to prevent
-                    // yaml editor from simplifying it to be "3" or "1".
+                    // CAMP editor from simplifying it to be "3" or "1".
                     throw 'decimal ending with dot or 0, eg version, treat as string';
                 }
                 // numbers and booleans are unquoted

--- a/ui-modules/blueprint-composer/app/index.js
+++ b/ui-modules/blueprint-composer/app/index.js
@@ -124,7 +124,7 @@ function tabConfig(tabServiceProvider, composerOverridesProvider) {
         stateKey: 'main.graphical'
     });
     tabServiceProvider.addTab('yaml', {
-        title: 'YAML Editor',
+        title: 'CAMP Editor',
         icon: 'fa-pencil',
         stateKey: 'main.yaml_camp',
     });

--- a/ui-modules/blueprint-composer/app/views/main/main.controller.js
+++ b/ui-modules/blueprint-composer/app/views/main/main.controller.js
@@ -192,7 +192,7 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
 
         $scope.initialYamlFormat = $stateParams.format;
         if($scope.initialYamlFormat && Array.isArray(edit.type.specList) && edit.type.specList.length > 0 && edit.type.specList[0].format === $scope.initialYamlFormat) {
-            yaml = edit.type.specList[0].contents; // for YAML editor
+            yaml = edit.type.specList[0].contents; // for CAMP editor
         }  else {
             // for graphical editor
             yaml = edit.type.plan.data;
@@ -218,7 +218,7 @@ export function MainController($scope, $element, $log, $state, $stateParams, brB
             try {
                 blueprintService.setFromYaml(yaml);
             } catch (e) {
-                console.warn("YAML supplied for editing is not valid for a blueprint. It will be ignored unless opened in the YAML editor:", e);
+                console.warn("YAML supplied for editing is not valid for a blueprint. It will be ignored unless opened in the CAMP editor:", e);
                 blueprintService.reset();
                 $scope.initialYaml = yaml;
             }

--- a/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
+++ b/ui-modules/blueprint-composer/app/views/main/yaml/yaml.state.js
@@ -33,7 +33,7 @@ export const yamlCampState = {
     controller: ['$scope', 'blueprintService', 'brSnackbar', yamlCampStateController],
     controllerAs: 'vm',
     data: {
-        label: 'YAML Editor'
+        label: 'CAMP Editor'
     }
 };
 


### PR DESCRIPTION
Replacing the name for the text editor exposes more clear the standard used instead the language language used to write the blueprint. This opens more clearly to add support to other standards 