### PR TITLE
Reference property by component ID instead of parent in DSL editor

### DIFF
--- a/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
+++ b/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
@@ -365,9 +365,6 @@ export function dslEditorDirective($rootScope, $filter, $log, brUtilsGeneral, bl
         if (entity === targetEntity) {
             return new Dsl(KIND.TARGET, TARGET.SELF);
         }
-        if (entity.parent === targetEntity) {
-            return new Dsl(KIND.TARGET, TARGET.PARENT);
-        }
 
         if (!targetEntity.hasId()) {
             if (brUtilsGeneral.isNonEmpty(state.entityId)) {


### PR DESCRIPTION
Signed-off-by: Mykola Mandra <mykola.mandra@cloudsoft.io>