### PR TITLE
Persistence import directive / export download implementation

### DIFF
--- a/ui-modules/home/app/index.html
+++ b/ui-modules/home/app/index.html
@@ -25,7 +25,7 @@
         <link rel="icon" type="image/png" href="${require('!!file-loader!<%= brand.product.favicon %>')}"/>
         <title><%= getBrandedText('product.name' )%> - <%= app.appname %></title>
     </head>
-    <body ng-app="brooklynHome" br-server-status ng-strict-di>
+    <body ng-app="brooklynHome" br-server-status ng-strict-di brooklyn-persistence-importer="open-persistence-importer">
         ${require('ejs-html!brooklyn-shared/partials/header-hero.html')}
 
         <main class="page-main-area" id="main-content" ui-view ng-cloak></main>

--- a/ui-modules/home/app/index.js
+++ b/ui-modules/home/app/index.js
@@ -35,6 +35,7 @@ import mainDeployState from 'views/main/deploy/deploy.controller';
 import aboutState from 'views/about/about.controller';
 import brLogbook from 'brooklyn-ui-utils/logbook/logbook';
 import quickLaunchOverrides from 'brooklyn-ui-utils/providers/quick-launch-overrides.provider';
+import brooklynPersistenceImporter from 'brooklyn-ui-utils/persistence-importer/persistence-importer';
 
 import brandAngularJs from 'brand-angular-js';
 
@@ -42,7 +43,7 @@ const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
 angular.module('brooklynHome', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brIconGenerator,
     brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brooklynQuickLaunch, mainState, mainDeployState,
-    aboutState, brLogbook, quickLaunchOverrides, brandAngularJs])
+    aboutState, brLogbook, quickLaunchOverrides, brooklynPersistenceImporter, brandAngularJs])
     .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$http', httpConfig]);
 

--- a/ui-modules/home/app/index.less
+++ b/ui-modules/home/app/index.less
@@ -24,6 +24,7 @@
 @import '~brooklyn-ui-utils/logbook/logbook.less';
 @import '~brooklyn-ui-utils/yaml-editor/yaml-editor.less';
 @import '~brooklyn-ui-utils/quick-launch/quick-launch.less';
+@import '~brooklyn-ui-utils/persistence-importer/persistence-importer.less';
 
 // Add project less files here
 @import 'views/main/main';

--- a/ui-modules/home/app/views/about/about.controller.js
+++ b/ui-modules/home/app/views/about/about.controller.js
@@ -45,7 +45,7 @@ export const aboutState = {
     name: 'about',
     url: '/about',
     template: template,
-    controller: ['$scope', '$element', '$q', '$uibModal', 'brBrandInfo', 'version', 'states', 'serverApi', aboutStateController],
+    controller: ['$scope', '$rootScope', '$element', '$q', '$uibModal', 'brBrandInfo', 'version', 'states', 'serverApi', aboutStateController],
     controllerAs: 'vm',
     resolve: {
         version: ['serverApi', (serverApi) => {
@@ -61,7 +61,7 @@ export function aboutStateConfig($stateProvider) {
     $stateProvider.state(aboutState);
 }
 
-export function aboutStateController($scope, $element, $q, $uibModal, brBrandInfo, version, states, serverApi) {
+export function aboutStateController($scope, $rootScope, $element, $q, $uibModal, brBrandInfo, version, states, serverApi) {
     $scope.$emit(HIDE_INTERSTITIAL_SPINNER_EVENT);
     $scope.getBrandedText = brBrandInfo.getBrandedText;
     $scope.serverVersion = version.data;
@@ -78,6 +78,14 @@ export function aboutStateController($scope, $element, $q, $uibModal, brBrandInf
     $scope.now = Date.now();
     $scope.expectedNodeCounter = Object.keys($scope.states.nodes).length;
     $scope.template = 'haStatusTemplate';
+
+    $scope.importPersistence = function () {
+        $rootScope.$broadcast('open-persistence-importer');
+    }
+
+    $scope.exportPersistence = function () {
+        // TODO
+    }
 
     let modalInstance = null;
 

--- a/ui-modules/home/app/views/about/about.controller.js
+++ b/ui-modules/home/app/views/about/about.controller.js
@@ -83,10 +83,6 @@ export function aboutStateController($scope, $rootScope, $element, $q, $uibModal
         $rootScope.$broadcast('open-persistence-importer');
     }
 
-    $scope.exportPersistence = function () {
-        // TODO
-    }
-
     let modalInstance = null;
 
     $scope.openDialog = function (states, container) {

--- a/ui-modules/home/app/views/about/about.template.html
+++ b/ui-modules/home/app/views/about/about.template.html
@@ -58,10 +58,12 @@
                 Persistence State Management
             </h2>
 
-            <button ng-click="importPersistence()"
-                    class="btn btn-sm btn-default">Import new persistence data</button>
-            <button ng-click="exportPersistence()"
-                    class="btn btn-sm btn-default">Export current persistence data</button>
+            <a ng-click="importPersistence()"
+               class="btn btn-default"
+               uib-tooltip="Imports new persistence data">Import</a>
+            <a ng-href="/v1/server/ha/persist/export?origin=AUTO" role="button"
+               class="btn btn-default" ng-class="type" download
+               uib-tooltip="Downloads the current persistence state into a zip archive">Export</a>
 
             <h2>
                 HA status

--- a/ui-modules/home/app/views/about/about.template.html
+++ b/ui-modules/home/app/views/about/about.template.html
@@ -55,6 +55,15 @@
             </ul>
 
             <h2>
+                Persistence State Management
+            </h2>
+
+            <button ng-click="importPersistence()"
+                    class="btn btn-sm btn-default">Import new persistence data</button>
+            <button ng-click="exportPersistence()"
+                    class="btn btn-sm btn-default">Export current persistence data</button>
+
+            <h2>
                 HA status
                 <button ng-if="states.nodes[states.ownId].status === 'MASTER'"
                         ng-click="removeAllTerminatedNodes()" class="btn btn-sm btn-default"

--- a/ui-modules/utils/api/brooklyn/server.js
+++ b/ui-modules/utils/api/brooklyn/server.js
@@ -50,6 +50,8 @@ function ServerApi($http, $q, cache) {
     this.removeHaTerminatedNodes = removeHaTerminatedNodes;
     this.removeHaTerminatedNode = removeHaTerminatedNode;
 
+    this.importPersistenceData = importPersistenceData;
+
     function getVersion(config) {
         return $http.get('/v1/server/version', angular.extend({cache: cache}, config));
     }
@@ -110,5 +112,9 @@ function ServerApi($http, $q, cache) {
             }
 
         });
+    }
+
+    function importPersistenceData(data, opts) {
+        return $http.post('v1/server/ha/persist/import', data, opts);
     }
 }

--- a/ui-modules/utils/persistence-importer/persistence-importer.html
+++ b/ui-modules/utils/persistence-importer/persistence-importer.html
@@ -1,0 +1,54 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<div class="brooklyn-persistence-importer">
+    <i class="fa fa-times target-close pull-right" ng-click="close()"></i>
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-12 text-center">
+                <p><i class="fa fa-3x fa-upload"></i></p>
+                <p>
+                    <input type="file" name="files" id="files" multiple custom-on-change="filesChanged" />
+                    <label for="files" ng-click="choose()"><strong>Choose files</strong><span class="drag-upload"> or drag & drop them here</span>.</label>
+                </p>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-sm-12 text-muted upload-item" ng-repeat="selectedFile in selectedFiles" ng-init="isDetailsCollapsed = true">
+                <div class="progress">
+                    <div class="progress-bar progress-bar-striped" role="progressbar" ng-class="{'active': !selectedFile.error && !selectedFile.result, 'progress-bar-danger': selectedFile.error, 'progress-bar-success': selectedFile.result}" style="width: 100%">
+                        <span ng-if="!selectedFile.result && !selectedFile.error">Importing</span> {{selectedFile.name}}
+                    </div>
+                </div>
+                <p ng-click="isDetailsCollapsed = !isDetailsCollapsed" class="upload-item-details-link"><i class="fa fa-info-circle"></i> {{isDetailsCollapsed ? 'View' : 'hide'}} details</p>
+                <div uib-collapse="isDetailsCollapsed" class="upload-item-details">
+                    <p ng-if="selectedFile.result">Successfully imported the following items:
+                        <ul class="fa-ul">
+                            <li ng-repeat="(key, item) in selectedFile.result track by key">
+                                <i class="fa-li fa fa-check-square"></i>
+                                <a ng-href="{{getPersistenceItemUrl(item)}}">{{item.itemType}} {{item.symbolicName}}:{{item.version}}</a>
+                            </li>
+                        </ul>
+                    </p>
+                    <p ng-if="selectedFile.error">{{selectedFile.error}}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/ui-modules/utils/persistence-importer/persistence-importer.html
+++ b/ui-modules/utils/persistence-importer/persistence-importer.html
@@ -16,6 +16,10 @@
   specific language governing permissions and limitations
   under the License.
 -->
+
+<!--
+TODO - Merge with implementation for catalog uploader for a reusable general uploader directive
+-->
 <div class="brooklyn-persistence-importer">
     <i class="fa fa-times target-close pull-right" ng-click="close()"></i>
     <div class="container">
@@ -23,8 +27,8 @@
             <div class="col-sm-12 text-center">
                 <p><i class="fa fa-3x fa-upload"></i></p>
                 <p>
-                    <input type="file" name="files" id="files" multiple custom-on-change="filesChanged" />
-                    <label for="files" ng-click="choose()"><strong>Choose files</strong><span class="drag-upload"> or drag & drop them here</span>.</label>
+                    <input type="file" name="files" id="files" custom-on-change="filesChanged" />
+                    <label for="files" ng-click="choose()"><strong>Choose file</strong><span class="drag-upload"> or drag & drop it here</span>.</label>
                 </p>
             </div>
         </div>

--- a/ui-modules/utils/persistence-importer/persistence-importer.html
+++ b/ui-modules/utils/persistence-importer/persistence-importer.html
@@ -37,20 +37,13 @@ TODO - Merge with implementation for catalog uploader for a reusable general upl
             <div class="col-sm-12 text-muted upload-item" ng-repeat="selectedFile in selectedFiles" ng-init="isDetailsCollapsed = true">
                 <div class="progress">
                     <div class="progress-bar progress-bar-striped" role="progressbar" ng-class="{'active': !selectedFile.error && !selectedFile.result, 'progress-bar-danger': selectedFile.error, 'progress-bar-success': selectedFile.result}" style="width: 100%">
-                        <span ng-if="!selectedFile.result && !selectedFile.error">Importing</span> {{selectedFile.name}}
+                        <span ng-if="!selectedFile.result && !selectedFile.error">Importing</span>
+                        <span ng-if="selectedFile.error">Error importing</span>
+                        <span ng-if="selectedFile.result">Successfully imported</span> {{selectedFile.name}}
                     </div>
                 </div>
-                <p ng-click="isDetailsCollapsed = !isDetailsCollapsed" class="upload-item-details-link"><i class="fa fa-info-circle"></i> {{isDetailsCollapsed ? 'View' : 'hide'}} details</p>
-                <div uib-collapse="isDetailsCollapsed" class="upload-item-details">
-                    <p ng-if="selectedFile.result">Successfully imported the following items:
-                        <ul class="fa-ul">
-                            <li ng-repeat="(key, item) in selectedFile.result track by key">
-                                <i class="fa-li fa fa-check-square"></i>
-                                <a ng-href="{{getPersistenceItemUrl(item)}}">{{item.itemType}} {{item.symbolicName}}:{{item.version}}</a>
-                            </li>
-                        </ul>
-                    </p>
-                    <p ng-if="selectedFile.error">{{selectedFile.error}}</p>
+                <div>
+                    <span ng-if="selectedFile.error">Error details: {{selectedFile.error.data.message}}</span>
                 </div>
             </div>
         </div>

--- a/ui-modules/utils/persistence-importer/persistence-importer.js
+++ b/ui-modules/utils/persistence-importer/persistence-importer.js
@@ -137,21 +137,10 @@ export function persistenceImporterDirective($compile, brooklynPersistenceImport
  */
 export function persistenceImporterService($q, serverApi) {
     let extensions = {
-        'bom': {
-            headers: {'Content-Type': 'application/yaml'}
-        },
-        'yml': {
-            headers: {'Content-Type': 'application/yaml'}
-        },
-        'yaml': {
-            headers: {'Content-Type': 'application/yaml'}
-        },
         'zip' : {
-            headers: {'Content-Type': 'application/x-zip'},
-            transformRequest: angular.identity
-        },
-        'jar' : {
-            headers: {'Content-Type': 'application/x-jar'},
+            headers: {  'Content-Type': 'multipart/form-data',
+                        'Accept': 'application/json',
+                        'Brooklyn-Allow-Non-Master-Access': 'true'},
             transformRequest: angular.identity
         }
     };
@@ -189,8 +178,7 @@ export function persistenceImporterService($q, serverApi) {
                 reader.addEventListener('load', ()=> {
                     try {
                         let rawData = new Uint8Array(reader.result);
-                        let data = ['zip', 'jar'].indexOf(extension) > -1 ? rawData : String.fromCharCode.apply(null, rawData);
-                        serverApi.create(data, {}, options).then((response)=> {
+                        serverApi.importPersistenceData(rawData, options).then((response)=> {
                             defer.resolve(response);
                         }).catch((response)=> {
                             defer.reject('Cannot upload item to the persistence: ' + response.error.message);

--- a/ui-modules/utils/persistence-importer/persistence-importer.js
+++ b/ui-modules/utils/persistence-importer/persistence-importer.js
@@ -181,9 +181,11 @@ export function persistenceImporterService($q, serverApi) {
                         serverApi.importPersistenceData(rawData, options).then((response)=> {
                             defer.resolve(response);
                         }).catch((response)=> {
+                            file.error = response;
                             defer.reject('Cannot upload item to the persistence: ' + response.error.message);
                         });
                     } catch (error) {
+                        file.error = error;
                         defer.reject('Cannot read file: ' + error.message);
                     }
                 }, false);

--- a/ui-modules/utils/persistence-importer/persistence-importer.js
+++ b/ui-modules/utils/persistence-importer/persistence-importer.js
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import angular from 'angular';
+import template from './persistence-importer.html';
+import serverApi from '../../utils/api/brooklyn/server.js';
+
+const MODULE_NAME = 'brooklyn.components.persistence-importer';
+
+/**
+ * @ngdoc module
+ * @name brooklyn.components.persistence-importer
+ * @requires serverApi
+ *
+ * @description
+ * TODO
+ */
+angular.module(MODULE_NAME, [serverApi])
+    .service('brooklynPersistenceImporter', ['$q', 'serverApi', persistenceImporterService])
+    .directive('customOnChange', customOnChangeDirective)
+    .directive('brooklynPersistenceImporter', ['$compile', 'brooklynPersistenceImporter', persistenceImporterDirective]);
+
+export default MODULE_NAME;
+
+/**
+ * @ngdoc directive
+ * @name brooklynPersistenceImporter
+ * @module brooklyn.components.persistence-importer
+ * @restrict A
+ *
+ * @description
+ * TODO
+ *
+ * @param {string} brooklynPersistenceImporter The value can be empty. Otherwise, the directive will listen for any event broadcasted
+ * with this name and will trigger the overlay upon reception.
+ */
+export function persistenceImporterDirective($compile, brooklynPersistenceImporter) {
+    return {
+        restrict: 'A',
+        link: link
+    };
+
+    function link(scope, element, attrs) {
+        let div = document.createElement('div');
+        if ((('draggable' in div) || ('ondragstart' in div && 'ondrop' in div)) && 'FormData' in window && 'FileReader' in window) {
+            element.addClass('br-has-drag-upload');
+        }
+
+        element.append($compile(template)(scope));
+
+        let counter = 0;
+        element.bind('drag dragstart dragend dragover dragenter dragleave drop', (event)=> {
+            event.preventDefault();
+            event.stopPropagation();
+        }).bind('drag dragstart dragover dragenter', (event)=> {
+            event.dataTransfer.dropEffect = 'copy';
+            element.addClass('br-drag-active');
+        }).bind('dragenter', ()=> {
+            counter++;
+        }).bind('dragleave', (event)=> {
+            counter--;
+            if (counter === 0) {
+                element.removeClass('br-drag-active');
+            }
+        }).bind('drop', (event)=> {
+            scope.upload(event.dataTransfer.files);
+        });
+
+        let field = attrs.brooklynPersistenceImporter;
+        if (angular.isDefined(field)) {
+            scope.$on(field, ()=> {
+                counter++;
+                element.addClass('br-drag-active');
+            });
+        }
+
+        scope.selectedFiles = [];
+
+        scope.close = ()=> {
+            counter--;
+            element.removeClass('br-drag-active');
+        };
+
+        scope.filesChanged = (event)=> {
+            scope.upload(event.target.files);
+        };
+
+        scope.upload = (files)=> {
+            for (let i = 0; i < files.length; i++) {
+                let file = files[i];
+
+                brooklynPersistenceImporter.upload(file).then((data)=> {
+                    file.result = data;
+                }).catch((error)=> {
+                    file.error = error;
+                }).finally(()=> {
+                    scope.$applyAsync();
+                });
+
+                scope.selectedFiles.unshift(file);
+                scope.$apply();
+            }
+        };
+
+        scope.getPersistenceItemUrl = (item)=> {
+            let itemTraits = item.tags? item.tags.find(item => item.hasOwnProperty("traits")) : {"traits":[]};
+            return (item.supertypes ? item.supertypes : itemTraits.traits)
+                .includes('org.apache.brooklyn.api.location.Location')
+                ? `/brooklyn-ui-location-manager/#!/location?symbolicName=${item.symbolicName}&version=${item.version}`
+                : `/brooklyn-ui-persistence/#!/bundles/${item.containingBundle.split(':')[0]}/${item.containingBundle.split(':')[1]}/types/${item.symbolicName}/${item.version}`;
+        };
+    }
+}
+
+/**
+ * @ngdoc service
+ * @name brooklynPersistenceImporter
+ * @module brooklyn.components.persistence-importer
+ *
+ * @description
+ * Encapsulate the logic to validate files to upload to the persistence.
+ */
+export function persistenceImporterService($q, serverApi) {
+    let extensions = {
+        'bom': {
+            headers: {'Content-Type': 'application/yaml'}
+        },
+        'yml': {
+            headers: {'Content-Type': 'application/yaml'}
+        },
+        'yaml': {
+            headers: {'Content-Type': 'application/yaml'}
+        },
+        'zip' : {
+            headers: {'Content-Type': 'application/x-zip'},
+            transformRequest: angular.identity
+        },
+        'jar' : {
+            headers: {'Content-Type': 'application/x-jar'},
+            transformRequest: angular.identity
+        }
+    };
+
+    return {
+        /**
+         * @ngdoc method
+         * @name upload
+         * @methodOf brooklynPersistenceImporter
+         *
+         * @description
+         * Upload a file to the persistence. This will validate the extensions and reject the promises if the current one is
+         * not supported.
+         *
+         * @param {object} file A file object, representing a file to upload to the persistence.
+         *
+         * @return A promise that gets resolve if the upload *and* process of the file server side is successful; the
+         * resolve data contains the persistence items that have been added a map of `{id: item}`. Otherwise, the promise
+         * is rejected with the error message as parameter.
+         */
+        upload: upload
+    };
+
+    function upload(file) {
+        let defer = $q.defer();
+
+        if (new RegExp('^.*\.(' + Object.keys(extensions).join('|') + ')$').test(file.name)) {
+            Object.keys(extensions).forEach((extension)=> {
+                if (!new RegExp('^.*\.(' + extension + ')$').test(file.name)) {
+                    return;
+                }
+
+                let options = extensions[extension];
+                let reader = new FileReader();
+                reader.addEventListener('load', ()=> {
+                    try {
+                        let rawData = new Uint8Array(reader.result);
+                        let data = ['zip', 'jar'].indexOf(extension) > -1 ? rawData : String.fromCharCode.apply(null, rawData);
+                        serverApi.create(data, {}, options).then((response)=> {
+                            defer.resolve(response);
+                        }).catch((response)=> {
+                            defer.reject('Cannot upload item to the persistence: ' + response.error.message);
+                        });
+                    } catch (error) {
+                        defer.reject('Cannot read file: ' + error.message);
+                    }
+                }, false);
+                reader.readAsArrayBuffer(file);
+            });
+        } else {
+            defer.reject('Unsupported file type. Please upload only files with the following extensions: ' + Object.keys(extensions).map((extension)=>('*.' + extension)).join(', '));
+        }
+
+        return defer.promise;
+    }
+}
+
+export function customOnChangeDirective() {
+    return {
+        restrict: 'A',
+        link: function (scope, element, attrs) {
+            element.on('change', x => {
+                var onChangeHandler = scope.$eval(attrs.customOnChange);
+                onChangeHandler(x);
+            });
+            element.on('$destroy', function() {
+                element.off();
+            });
+        }
+    };
+}

--- a/ui-modules/utils/persistence-importer/persistence-importer.less
+++ b/ui-modules/utils/persistence-importer/persistence-importer.less
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+.brooklyn-persistence-importer {
+  padding: 50px;
+  z-index: 100;
+  visibility: hidden;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: white;
+  overflow-y: scroll;
+  transition: all 0.3s ease;
+  opacity: 0;
+
+  .upload-box {
+    background: @gray-lighter;
+    border: 5px @gray-light dashed;
+  }
+
+  .target-close {
+    cursor: pointer;
+  }
+
+  input[type=file] {
+    display: none;
+  }
+
+  label > strong {
+    text-decoration: underline;
+    cursor: pointer;
+    color: @brand-primary;
+  }
+
+  .upload-item {
+    margin-bottom: 1em;
+
+    .progress {
+      margin-bottom: 0;
+
+      .progress-bar {
+        transition: background-color 0.3s ease;
+      }
+    }
+    .upload-item-details-link {
+      cursor: pointer;
+    }
+  }
+}
+
+.br-drag-active .brooklyn-persistence-importer {
+  visibility: visible;
+  opacity: 1;
+}
+


### PR DESCRIPTION
Introducing a directive to allow uploading (importing) of a persistence store archive (currently zip only).
Introducing capability to download (export) the current persistent store.