### PR TITLE
attempt to fix WARN and ERROR on service creation, and tidy some references and logs

### DIFF
--- a/modularity-server/external-modules/pom.xml
+++ b/modularity-server/external-modules/pom.xml
@@ -103,9 +103,8 @@
                     <instructions>
 
       <!-- exportScr and below from https://felix.apache.org/documentation/faqs/apache-felix-bundle-plugin-faq.html -->
-      <!-- Enable processing of OSGI DS component annotations -->
+      <!-- Enable processing of OSGI DS component and metatype annotations - only needed for some type of tests it seems but no harm in having it --> 
       <_dsannotations>*</_dsannotations>
-      <!-- Enable processing of OSGI metatype annotations -->
       <_metatypeannotations>*</_metatypeannotations>
 
                         <Import-Package>

--- a/modularity-server/metadata-registry/pom.xml
+++ b/modularity-server/metadata-registry/pom.xml
@@ -114,10 +114,9 @@
                     <exportScr>true</exportScr>
                     <instructions>
 
-      <!-- exportScr and below from https://felix.apache.org/documentation/faqs/apache-felix-bundle-plugin-faq.html -->
-      <!-- Enable processing of OSGI DS component annotations -->
+      <!-- exportScr above and below from https://felix.apache.org/documentation/faqs/apache-felix-bundle-plugin-faq.html -->
+      <!-- Enable processing of OSGI DS component and metatype annotations - only needed for some type of tests it seems but no harm in having it -->
       <_dsannotations>*</_dsannotations>
-      <!-- Enable processing of OSGI metatype annotations -->
       <_metatypeannotations>*</_metatypeannotations>
 
                         <Import-Package>

--- a/modularity-server/metadata-registry/src/main/java/org/apache/brooklyn/ui/modularity/metadata/registry/impl/UiMetadataRegistryImpl.java
+++ b/modularity-server/metadata-registry/src/main/java/org/apache/brooklyn/ui/modularity/metadata/registry/impl/UiMetadataRegistryImpl.java
@@ -53,7 +53,6 @@ public class UiMetadataRegistryImpl implements UiMetadataRegistry {
 
     @Override
     public Map<String, Map<String, String>> getByType(final String type) {
-        logger.error(type);
         return metadataTable.row(type);
     }
 

--- a/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModuleListener.java
+++ b/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModuleListener.java
@@ -259,6 +259,7 @@ public class UiModuleListener implements ServletContextListener {
         }
         @SuppressWarnings("unchecked")
         Map<String, ?> config = (Map<String, ?>) new Yaml().load(is);
+        LOG.debug("Creating Brooklyn UI module definition for "+path+"; "+config+" / "+is);
         return UiModuleImpl.createFromMap(config).path(path);
     }
 }

--- a/modularity-server/module-registry/src/main/java/org/apache/brooklyn/ui/modularity/module/registry/UiModuleRegistryImpl.java
+++ b/modularity-server/module-registry/src/main/java/org/apache/brooklyn/ui/modularity/module/registry/UiModuleRegistryImpl.java
@@ -37,6 +37,10 @@ public class UiModuleRegistryImpl implements UiModuleRegistry {
     private final ConcurrentHashMap<String, UiModule> registry = new ConcurrentHashMap<>();
 
     public void register(final UiModule uiModule) {
+        if (uiModule.getId()==null) {
+            LOG.error("Skipping invalid Brooklyn UI module "+uiModule, new Throwable("source of error"));
+            return;
+        }
         LOG.info("Registering new Brooklyn web component [{}] [{}]", uiModule.getId(), uiModule.getName());
         registry.put(uiModule.getId(), uiModule);
     }


### PR DESCRIPTION
(1) metadata service appeared to have an inconsistent naming strategy; when i updated the PID/name as done here it worked perfectly, matching the location metadata cfg files we install.

(2) this also seems to for now get rid of these errors in the startup log

```
2021-09-01T09:07:05,357 - ERROR 374 o.a.b.u.m.ExternalUiModule [FelixStartLevel] bundle org.apache.brooklyn.ui.modularity.brooklyn-ui-external-modules:1.1.0.SNAPSHOT (374)[org.apache.brooklyn.ui.modularity.ExternalUiModule] : Cannot register component
2021-09-01T09:07:05,372 - ERROR 375 o.a.b.u.m.m.r.i.UiMetadataConfigListener [FelixStartLevel] bundle org.apache.brooklyn.ui.modularity.brooklyn-ui-metadata-registry:1.1.0.SNAPSHOT (375)[org.apache.brooklyn.ui.modularity.metadata.registry.impl.UiMetadataConfigListener] : Cannot register component
```

with detail

```
org.osgi.service.component.ComponentException: The component name 'Brooklyn UI Metadata' has already been registered by Bundle 375 (org.apache.brooklyn.ui.modularity.brooklyn-ui-metadata-registry) as Component of Class org.apache.brooklyn.ui.modularity.metadata.registry.impl.UiMetadataConfigListener
```

but i'm not convinced this will stick; it may be non-deterministic because i've made previous changes which seemed to fix it, but then they re-occurred, and here i made changes which fixed it then changed some things back and it still seemed to be fixed, but in the end the changes being made don't seem like they should fix the component registration error

(3) it also fixes this one which was clearly a debug logging mistake

```
2021-08-24T12:59:31,245 - ERROR 375 o.a.b.u.m.m.r.i.UiMetadataRegistryImpl [898600076-137202] location
```

(4) better logging for ui module registration in general
