### PR TITLE
Added fix for this

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -72,11 +72,11 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                         config
                             .filter(item => item instanceof Dsl)
                             .reduce((set, config) => {
-                                    config.relationships.forEach((entity) => {
-                                        if (entity !== null) {
-                                            set.add({entity: entity, name: key});
-                                        }
-                                    });
+                                config.relationships.forEach((entity) => {
+                                    if (entity !== null) {
+                                        set.add({entity: entity, name: key});
+                                    }
+                                });
                                 return set;
                             }, set);
                     }

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -72,11 +72,11 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                         config
                             .filter(item => item instanceof Dsl)
                             .reduce((set, config) => {
-                                config.relationships.forEach((entity) => {
-                                    if (entity !== null) {
-                                        set.add({entity: entity, name: key});
-                                    }
-                                });
+                                    config.relationships.forEach((entity) => {
+                                        if (entity !== null) {
+                                            set.add({entity: entity, name: key});
+                                        }
+                                    });
                                 return set;
                             }, set);
                     }
@@ -84,11 +84,14 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                         Object.keys(config)
                             .filter(objectKey => config[objectKey] instanceof Dsl)
                             .reduce((set, objectKey) => {
-                                config[key].relationships.forEach((entity)=> {
-                                    if (entity !== null) {
-                                        set.add({entity: entity, name: key});
-                                    }
-                                });
+                                if(config[key]) {  // when config[objectKey] value is a DSL, but the config does not have a [key] property
+                                    console.log("testing this: " , config[key], key, config, objectKey);
+                                    config[key].relationships.forEach((entity) => {
+                                        if (entity !== null) {
+                                            set.add({entity: entity, name: key});
+                                        }
+                                    });
+                                }
                                 return set;
                             }, set);
                     }
@@ -590,7 +593,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                     resolve(parsed);
                 }
             } catch (ex) {
-                $log.debug("Cannot detect whether this is a DSL expression; assuming not", ex);
+                $log.debug("Cannot detect whether this is a DSL expression; assuming not: " + input, ex);
                 reject(ex, input);
             }
         });

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -85,7 +85,6 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                             .filter(objectKey => config[objectKey] instanceof Dsl)
                             .reduce((set, objectKey) => {
                                 if(config[key]) {  // when config[objectKey] value is a DSL, but the config does not have a [key] property
-                                    console.log("testing this: " , config[key], key, config, objectKey);
                                     config[key].relationships.forEach((entity) => {
                                         if (entity !== null) {
                                             set.add({entity: entity, name: key});


### PR DESCRIPTION
... actually a `config[key]` was undefinded and breaking the composer. This happens when config values are maps containign DSL values, such as the 3tier app where tomcat is configured to connect to the database using a CAMP DSL expression. 

Bug introduced when adapting Brooklyn UI to accept redering of relationships.