### PR TITLE
UI awareness of configurable sensitive fields

### DIFF
--- a/ui-modules/app-inspector/app/components/config-sensor-table/config-sensor-table.directive.js
+++ b/ui-modules/app-inspector/app/components/config-sensor-table/config-sensor-table.directive.js
@@ -20,7 +20,7 @@ import angular from "angular";
 import ngSanitize from "angular-sanitize";
 import ngClipboard from "ngclipboard";
 import template from "./config-sensor-table.template.html";
-import { SENSITIVE_FIELD_REGEX } from "brooklyn-ui-utils/sensitive-field/sensitive-field";
+import { isSensitiveFieldName } from "brooklyn-ui-utils/sensitive-field/sensitive-field";
 
 const MODULE_NAME = 'inspector.config-sensor.table';
 
@@ -85,7 +85,7 @@ export function brLinkyFilter($filter, $state, $sanitize) {
         } else if (!angular.isString(input)) {
             return angular.toJson(input);
         } else if (angular.isObject(key) && angular.isString(key.name)
-            && (key.name.indexOf('ssh') > -1 || SENSITIVE_FIELD_REGEX.test(key.name))) {
+            && (key.name.indexOf('ssh') > -1 || isSensitiveFieldName(key.name))) {
             return input;
         } else if (angular.isObject(key) && key.links && key.links.hasOwnProperty('action:open')) {
             let matches = key.links['action:open'].match(/\#\/v1\/applications\/([^\/]+)\/entities\/([^\/]+)/i);

--- a/ui-modules/app-inspector/app/components/config-sensor-table/config-sensor-table.directive.js
+++ b/ui-modules/app-inspector/app/components/config-sensor-table/config-sensor-table.directive.js
@@ -44,7 +44,7 @@ export function configSensorTableDirective(brSnackbar) {
     function link(scope) {
         scope.items = [];
         scope.mapInfo = {};
-        scope.WARNING_TEXT = 'This value is identified as potentially sensitive based on the name and so it ' +
+        scope.WARNING_TEXT = 'This value is identified as potentially sensitive based on the name and so is ' +
             'blurred here by default. However it is supplied in the blueprint as plaintext which is not secure. An ' +
             'external provider should be used to store this value with a DSL expression supplied in the blueprint to ' +
             'retrieve the value.';

--- a/ui-modules/app-inspector/app/views/main/inspect/summary/summary.controller.js
+++ b/ui-modules/app-inspector/app/views/main/inspect/summary/summary.controller.js
@@ -20,7 +20,7 @@ import angular from "angular";
 import map from "lodash/map";
 import {HIDE_INTERSTITIAL_SPINNER_EVENT} from 'brooklyn-ui-utils/interstitial-spinner/interstitial-spinner';
 import template from "./summary.template.html";
-import { SENSITIVE_FIELD_REGEX } from 'brooklyn-ui-utils/sensitive-field/sensitive-field';
+import { isSensitiveFieldName } from 'brooklyn-ui-utils/sensitive-field/sensitive-field';
 
 export const summaryState = {
     name: 'main.inspect.summary',
@@ -106,7 +106,7 @@ export function summaryController($scope, $state, $stateParams, $q, $http, $http
                         value,
                         // marking as unsafe if the field name looks sensitive
                         // and the unresolved value does *not* come from a secure external source
-                        isUnsafe: SENSITIVE_FIELD_REGEX.test(key.trim()) &&
+                        isUnsafe: isSensitiveFieldName(key.trim()) &&
                             !vm.config[key].toString().startsWith('$brooklyn:'),
                     }));
             }

--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.less
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.less
@@ -25,3 +25,9 @@
     width: 400px;
   }
 }
+
+.add-to-catalog-modal {
+  .error-scroll {
+    overflow: scroll;
+  }
+}

--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.modal.template.html
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.modal.template.html
@@ -127,9 +127,9 @@
         </div>
     </div>
 
-    <div uib-alert class="alert-danger" ng-if="state.error" dismiss-on-timeout="10000" close="state.error = undefined">
+    <div uib-alert class="alert-danger" ng-if="state.error" close="state.error = undefined">
         <h4>Failed to save</h4>
-        <p>{{state.error}}</p>
+        <p class="error-scroll">{{state.error}}</p>
     </div>
 </div>
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -28,7 +28,7 @@ import brooklynDslEditor from '../dsl-editor/dsl-editor';
 import brooklynDslViewer from '../dsl-viewer/dsl-viewer';
 import template from './spec-editor.template.html';
 import {graphicalState} from '../../views/main/graphical/graphical.state';
-import {SENSITIVE_FIELD_REGEX} from 'brooklyn-ui-utils/sensitive-field/sensitive-field';
+import {isSensitiveFieldName} from 'brooklyn-ui-utils/sensitive-field/sensitive-field';
 import {computeQuickFixesForIssue} from '../quick-fix/quick-fix';
 import scriptTagDecorator from 'brooklyn-ui-utils/script-tag-non-overwrite/script-tag-non-overwrite';
 
@@ -772,7 +772,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         };
         specEditor.isSensitiveField = (item) => {
             // should the field support masking
-            return SENSITIVE_FIELD_REGEX.test(item.name);
+            return isSensitiveFieldName(item.name);
         };
         specEditor.isHiddenSensitiveField = (item) => {
             // is the field currently in a masked state

--- a/ui-modules/utils/sensitive-field/sensitive-field.js
+++ b/ui-modules/utils/sensitive-field/sensitive-field.js
@@ -19,7 +19,6 @@
 import angular from 'angular';
 
 const MODULE_NAME = 'brooklyn.component.sensitive-field';
-export const SENSITIVE_FIELD_REGEX = /^.*(passw(or)?d|credentials?|secret|private|access\.certs?|access\.keys?).*$/i;
 const CLASS_NAME = 'sensitive-field';
 const CLASS_NAME_SHOW = 'sensitive-field-show';
 
@@ -28,6 +27,26 @@ angular.module(MODULE_NAME, [])
 
 export default MODULE_NAME;
 
+var SENSITIVE_FIELDS = ['password','passwd','credential','secret','private','access.certs','access.keys'];
+var SENSITIVE_FIELDS_BLOCKED = false;
+
+export function isSensitiveFieldPlaintextValueBlocked() {
+    return SENSITIVE_FIELDS_BLOCKED;
+}
+export function isSensitiveFieldName(name) {
+    if (!name && !name.toLowerCase) return false;
+    let ln = name.toLowerCase();
+    return !! SENSITIVE_FIELDS.find(f => ln.indexOf(f)>=0);
+}
+export function setSensitiveFields(list, blocked) {
+    let old = SENSITIVE_FIELDS;
+    if (blocked === true || blocked === false) {
+        SENSITIVE_FIELDS_BLOCKED = blocked;
+    }
+    if (list) SENSITIVE_FIELDS = list;
+    return old;
+}
+
 export function SensitiveFieldDirective() {
     return {
         restrict: 'A',
@@ -35,7 +54,7 @@ export function SensitiveFieldDirective() {
         link: link
     };
     function link($scope, $element) {
-        if (SENSITIVE_FIELD_REGEX.test($scope.fieldName.trim()) || $scope.hideValue) {
+        if (isSensitiveFieldName($scope.fieldName.trim()) || $scope.hideValue) {
             $element.addClass(CLASS_NAME);
             $element.bind('click', clickEventHandler);
         } else {

--- a/ui-modules/utils/server-status/server-status.js
+++ b/ui-modules/utils/server-status/server-status.js
@@ -21,6 +21,7 @@ import './server-status.less';
 import angular from 'angular';
 import uibModal from 'angular-ui-bootstrap/src/modal/index-nocss';
 import modalTemplate from './server-status.template.html';
+import {setSensitiveFields} from "../sensitive-field/sensitive-field";
 
 const MODULE_NAME = 'br.utils.server-status';
 const COOKIE_KEY = "br-server-status";
@@ -94,6 +95,11 @@ export function BrServerStatusDirective() {
                     state = BrServerStatusModalController.STATES.NOT_HA_MASTER;
                 } else if (!stateData.healthy) {
                     state = BrServerStatusModalController.STATES.UNHEALTHY;
+                }
+
+                let sensitiveFields = stateData['brooklyn.security.sensitive.fields'];
+                if (sensitiveFields) {
+                    setSensitiveFields(sensitiveFields.tokens, sensitiveFields['plaintext.blocked']);
                 }
             }
             previousState = state;


### PR DESCRIPTION
sensitive fields and whether deployments are blocked are now loaded from the server and set dynamically where used (eg in config values table); and in composer, if plaintext values are blocked a warning appears when the field is being edited

![image](https://user-images.githubusercontent.com/496540/133427050-9363d4cf-5dcb-41bb-8deb-5536dbfc71d0.png)
