### PR TITLE
ensuring that tosca post processors are not applied if type is camp

### DIFF
--- a/ui-modules/catalog/app/views/bundle/type/type.state.js
+++ b/ui-modules/catalog/app/views/bundle/type/type.state.js
@@ -126,6 +126,7 @@ export function typeController($scope, $state, $stateParams, $q, $uibModal, brBr
         $scope.type = responses[1];
         this.specItem = $scope.type.specList[0];
         $scope.typeFormat = this.specItem.format ? 'format=' + this.specItem.format + '&' : '';
+        $scope.type.plan.format = this.specItem.format;
         $scope.versions = responses[2].map(typeVersion => ({
             bundleSymbolicName: typeVersion.containingBundle.split(':')[0],
             bundleVersion: typeVersion.containingBundle.split(':')[1],

--- a/ui-modules/utils/quick-launch/quick-launch.js
+++ b/ui-modules/utils/quick-launch/quick-launch.js
@@ -150,8 +150,7 @@ export function quickLaunchDirective() {
 
         function deployApp() {
             $scope.deploying = true;
-            let useExtensions = $scope.app.plan.format.includes('camp') ? false : true;
-            Promise.resolve(quickLaunch.buildYaml(useExtensions))
+            Promise.resolve(quickLaunch.buildYaml($scope.app.plan.format.includes('camp') ? false : true))
                 .then(appYaml => {
                     quickLaunch.planSender(appYaml)
                         .then((response) => {

--- a/ui-modules/utils/quick-launch/quick-launch.js
+++ b/ui-modules/utils/quick-launch/quick-launch.js
@@ -150,8 +150,8 @@ export function quickLaunchDirective() {
 
         function deployApp() {
             $scope.deploying = true;
-
-            Promise.resolve(quickLaunch.buildYaml())
+            let useExtensions = $scope.app.plan.format.includes('camp') ? false : true;
+            Promise.resolve(quickLaunch.buildYaml(useExtensions))
                 .then(appYaml => {
                     quickLaunch.planSender(appYaml)
                         .then((response) => {


### PR DESCRIPTION
For support of both camp and tosca types at the same time:

Previously:
camp type had a post processor applied to it, that translated it to tosca
API to process the deployment on the server side received the tosca 1.3 template with format as tosca13
server translate the template back to camp and deploys the application

Above is unnecessary conversion back and forward and also has some side effects (such as an unnecessary delete effector).

With the change:
if using camp type, we don't apply post processors
API sends a camp template to the server