### PR TITLE
Focus parent after entity deletion

### DIFF
--- a/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
+++ b/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
@@ -154,26 +154,28 @@ export function designerDirective($log, $state, $q, $rootScope, iconGenerator, c
 
         $element.bind('click-entity', (event) => {
             $scope.$apply(() => {
-                $log.debug(TAG + 'edit node ' + event.detail.entity._id, event.detail.entity);
-                switch (event.detail.entity.family) {
+                const clickedEntity = event.detail.entity;
+                $log.debug(TAG + 'edit node ' + clickedEntity._id, clickedEntity);
+                switch (clickedEntity.family) {
                     case EntityFamily.ENTITY:
                         const blueprint = blueprintService.get();
                         if (blueprint.isInDslEdit) {
-                            $rootScope.$broadcast('d3.entity-selected', event.detail.entity);
+                            $rootScope.$broadcast('d3.entity-selected', clickedEntity);
                             blueprintGraph.hideShadow();
-                            blueprintGraph.dropShadow(event.detail.entity._id);
+                            blueprintGraph.dropShadow(clickedEntity._id);
                         } else {
-                            $state.go(graphicalEditEntityState, {entityId: event.detail.entity._id});
+                            console.log('Entity parent', clickedEntity.hasParent(), clickedEntity.parent);
+                            $state.go(graphicalEditEntityState, {entityId: clickedEntity._id});
                         }
                         break;
                     case EntityFamily.SPEC:
-                        $state.go(graphicalEditSpecState, {entityId: event.detail.entity.parent._id, specId: event.detail.entity._id});
+                        $state.go(graphicalEditSpecState, {entityId: clickedEntity.parent._id, specId: clickedEntity._id});
                         break;
                     case EntityFamily.POLICY:
-                        $state.go(graphicalEditPolicyState, {entityId: event.detail.entity.parent._id, policyId: event.detail.entity._id});
+                        $state.go(graphicalEditPolicyState, {entityId: clickedEntity.parent._id, policyId: clickedEntity._id});
                         break;
                     case EntityFamily.ENRICHER:
-                        $state.go(graphicalEditEnricherState, {entityId: event.detail.entity.parent._id, enricherId: event.detail.entity._id});
+                        $state.go(graphicalEditEnricherState, {entityId: clickedEntity.parent._id, enricherId: clickedEntity._id});
                         break;
                 }
             });
@@ -215,7 +217,13 @@ export function designerDirective($log, $state, $q, $rootScope, iconGenerator, c
 
         $element.bind('delete-entity', function (event) {
             $log.debug('delete-entity');
-            $scope.$broadcast('d3.remove', event.detail.entity);
+            const entityToDelete = event.detail.entity;
+
+            if (entityToDelete.hasParent()) {
+                $state.go(graphicalEditEntityState, { entityId: entityToDelete.parent._id });
+            }
+
+            $scope.$broadcast('d3.remove', entityToDelete);
         });
 
         $element.bind('graph-redrawn', () => $scope.$root.$broadcast('layers.filter'));


### PR DESCRIPTION
When deleting an Entity in Graphical editor the parent is focused if it has one

Prevents add to <missing node> cases when adding from the left sidebar