### PR TITLE
Change ui-metadata-registry maven module type

### DIFF
--- a/modularity-server/metadata-registry/pom.xml
+++ b/modularity-server/metadata-registry/pom.xml
@@ -30,7 +30,7 @@
 
     <artifactId>brooklyn-ui-metadata-registry</artifactId>
     <name>Brooklyn UI :: Modularity Server :: UI Metadata Registry</name>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Change this back to a `bundle` instead of a `jar`. This is because it contains a karaf config listener which does not run if it's not a `bundle`, hence the config files are not loaded rendering this module useless