### PR TITLE
Add `order` as module property and use it when is present before using name for ordering modules

### DIFF
--- a/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModule.java
+++ b/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/UiModule.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.ui.modularity.module.api.internal.UiModuleImpl;
 
 public interface UiModule {
     String DEFAULT_ICON = "fa-cogs";
+    int DEFAULT_ORDER = 10_000;
 
     /**
      * @return The unique ID of the module
@@ -71,7 +72,10 @@ public interface UiModule {
      * @return Registered module actions
      */
     List<UiModuleAction> getActions();
-    
+
+    default int getOrder(){
+        return DEFAULT_ORDER;
+    }
     public class Utils {
         public static UiModule copyUiModule(UiModule src) {
             return UiModuleImpl.copyOf(src);

--- a/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/internal/UiModuleImpl.java
+++ b/modularity-server/module-api/src/main/java/org/apache/brooklyn/ui/modularity/module/api/internal/UiModuleImpl.java
@@ -40,11 +40,12 @@ public class UiModuleImpl implements UiModule {
     private boolean stopExisting = true;
     private String path;
     private List<UiModuleAction> actions = new ArrayList<>();
-
+    private int order;
     public static UiModuleImpl copyOf(UiModule src) {
         final UiModuleImpl result = new UiModuleImpl();
         result.setId(src.getId());
         result.setName(src.getName());
+        result.setOrder(src.getOrder());
         result.setSlug(src.getSlug());
         result.setIcon(src.getIcon());
         if (src.getTypes()!=null) result.types.addAll(src.getTypes());
@@ -59,6 +60,7 @@ public class UiModuleImpl implements UiModule {
         final UiModuleImpl result = new UiModuleImpl();
         result.setId(Optional.fromNullable((String) incomingMap.get("id")).or(UUID.randomUUID().toString()));
         result.setName(Optional.fromNullable((String) incomingMap.get("name")).or(result.getId()));
+        result.setOrder(Optional.fromNullable((Integer) incomingMap.get("order")).or(UiModule.DEFAULT_ORDER));
         result.setSlug((String) incomingMap.get("slug"));
         result.setIcon(Optional.fromNullable((String) incomingMap.get("icon")).or(DEFAULT_ICON));
         final Object types = incomingMap.get("types");
@@ -132,6 +134,10 @@ public class UiModuleImpl implements UiModule {
         return actions;
     }
 
+    @Override
+    public int getOrder() {
+        return order;
+    }
     public void setId(final String id) {
         this.id = id;
     }
@@ -144,6 +150,9 @@ public class UiModuleImpl implements UiModule {
         this.name = name;
     }
 
+    public void setOrder(final int order){
+        this.order = order;
+    }
     public void setSlug(final String slug) {
         this.slug = slug;
     }
@@ -200,6 +209,11 @@ public class UiModuleImpl implements UiModule {
 
     public UiModuleImpl action(final UiModuleAction action) {
         actions.add(action);
+        return this;
+    }
+
+    public UiModuleImpl order(final int order) {
+        this.order=order;
         return this;
     }
 }

--- a/ui-modules/app-inspector/package.json
+++ b/ui-modules/app-inspector/package.json
@@ -37,7 +37,7 @@
     "npm": ">=5.0.0"
   },
   "brooklyn": {
-    "appname": "App Inspector"
+    "appname": "Inspector"
   },
   "dependencies": {
     "angular": "^1.6.1",

--- a/ui-modules/app-inspector/src/main/resources/ui-module/config.yaml
+++ b/ui-modules/app-inspector/src/main/resources/ui-module/config.yaml
@@ -15,7 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-name: App Inspector
+name: Inspector
+order: 10
 slug: ${project.artifactId}
 icon: fa-search
 types:

--- a/ui-modules/home/app/index.js
+++ b/ui-modules/home/app/index.js
@@ -29,6 +29,7 @@ import brooklynModuleLinks from 'brooklyn-ui-utils/module-links/module-links';
 import brooklynQuickLaunch from 'brooklyn-ui-utils/quick-launch/quick-launch';
 import brServerStatus from 'brooklyn-ui-utils/server-status/server-status';
 import brooklynUserManagement from 'brooklyn-ui-utils/user-management/user-management';
+import brUtilsGeneral from "brooklyn-ui-utils/utils/general";
 
 import mainState from 'views/main/main.controller';
 import mainDeployState from 'views/main/deploy/deploy.controller';
@@ -43,7 +44,7 @@ const IS_PRODUCTION = process.env.NODE_ENV === 'production' || false;
 
 angular.module('brooklynHome', [ngAnimate, ngCookies, uiRouter, brCore, brServerStatus, brIconGenerator,
     brInterstitialSpinner, brooklynModuleLinks, brooklynUserManagement, brooklynQuickLaunch, mainState, mainDeployState,
-    aboutState, brLogbook, quickLaunchOverrides, brooklynPersistenceImporter, brandAngularJs])
+    aboutState, brLogbook, quickLaunchOverrides, brooklynPersistenceImporter, brUtilsGeneral, brandAngularJs])
     .config(['$urlRouterProvider', '$logProvider', '$compileProvider', applicationConfig])
     .run(['$http', httpConfig]);
 

--- a/ui-modules/home/app/views/main/main.controller.js
+++ b/ui-modules/home/app/views/main/main.controller.js
@@ -34,7 +34,7 @@ export const mainState = {
     name: 'main',
     url: '/',
     template: template,
-    controller: ['$scope', '$state', 'uiModules', 'catalogApps', mainStateController],
+    controller: ['$scope', '$state', 'uiModules', 'catalogApps', 'brUtilsGeneral', mainStateController],
     controllerAs: 'vm',
     resolve: {
         uiModules: ['brooklynUiModulesApi', (brooklynUiModulesApi) => {
@@ -72,10 +72,12 @@ export function mainStateConfig($stateProvider) {
     $stateProvider.state(mainState);
 }
 
-export function mainStateController($scope, $state, uiModules, catalogApps) {
+export function mainStateController($scope, $state, uiModules, catalogApps, brUtilsGeneral) {
     $scope.$emit(HIDE_INTERSTITIAL_SPINNER_EVENT);
 
-    this.uiModules = uiModules.filter(({ types }) => types.includes('home-ui-module'));
+    this.uiModules = uiModules
+        .filter(({ types }) => types.includes('home-ui-module'))
+        .sort(brUtilsGeneral.uiModuleComparator);
     this.catalogApps = catalogApps;
 
     this.pagination = {

--- a/ui-modules/login/package-lock.json
+++ b/ui-modules/login/package-lock.json
@@ -20859,8 +20859,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
@@ -26122,8 +26121,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.2.tgz",
           "integrity": "sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM=",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "karma-phantomjs-launcher": {
           "version": "1.0.4",
@@ -32622,8 +32620,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.2.tgz",
       "integrity": "sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM=",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "karma-phantomjs-launcher": {
       "version": "1.0.4",

--- a/ui-modules/utils/module-links/module-links.js
+++ b/ui-modules/utils/module-links/module-links.js
@@ -36,7 +36,7 @@ export function moduleLinksMenuDirective($compile) {
         terminal: true,
         priority: 1000,
         link: link,
-        controller: ['brBrandInfo', 'brooklynUiModulesApi', controller],
+        controller: ['brBrandInfo', 'brooklynUiModulesApi', 'brUtilsGeneral', controller],
         controllerAs: 'ctrl'
     };
 
@@ -50,7 +50,7 @@ export function moduleLinksMenuDirective($compile) {
         $compile(element)(scope);
     }
 
-    function controller(brBrandInfo, brooklynUiModulesApi) {
+    function controller(brBrandInfo, brooklynUiModulesApi, brUtilsGeneral) {
         this.modules = null;
         this.isModuleActive = (path) => {
             if (path === '/' || path === '') {
@@ -62,7 +62,7 @@ export function moduleLinksMenuDirective($compile) {
 
         //Load Modules
         brooklynUiModulesApi.getUiModules().then(response => {
-            this.modules = response
+            this.modules = response.sort(brUtilsGeneral.uiModuleComparator)
         });
 
         this.productName = brBrandInfo.getBrandedText('product.name');

--- a/ui-modules/utils/utils/general.js
+++ b/ui-modules/utils/utils/general.js
@@ -54,10 +54,23 @@ export function isNonEmpty(object) {
     return true; 
 }
 
+export function uiModuleComparator(moduleA, moduleB) {
+    if(moduleA.order && moduleB.order){
+        if (moduleA.order > moduleB.order) {
+            return 1;
+        }
+        if(moduleA.order < moduleB.order) {
+            return -1;
+        }
+    }
+    // If no order implemented or is the same, order by name
+    return moduleA.name > moduleB.name ? 1: -1;
+}
 export function brUtilsGeneralProvider() {
     return { 
         isNonEmpty, 
-        capitalize 
+        capitalize,
+        uiModuleComparator
     };
 }
 

--- a/ui-modules/utils/utils/general.js
+++ b/ui-modules/utils/utils/general.js
@@ -36,39 +36,36 @@ export function capitalize(input) {
  * and anything with a length (string). also understands null and undefined.
  * 
  * useful instead of the refrain of (x!==null && x.length>0), or a bit worse for Object.
- */ 
+ */
 export function isNonEmpty(object) {
     if (typeof object === "undefined" || object == null) return false;
-    
+
     // treat arrays specially although I think the two methods below will always work for them
     if (Array.isArray(object)) return object.length > 0;
-    
+
     if (angular.isObject(object)) return Object.keys(object).length > 0;
 
     // other common falsey types            
     if (object == 0 || object == false) return false;
     // strings, maybe other things
     if (object.hasOwnProperty("length")) return object.length > 0;
-    
+
     // other objects will be complex or default to true
-    return true; 
+    return true;
 }
 
 export function uiModuleComparator(moduleA, moduleB) {
     if(moduleA.order && moduleB.order){
-        if (moduleA.order > moduleB.order) {
-            return 1;
-        }
-        if(moduleA.order < moduleB.order) {
-            return -1;
+        if (moduleA.order != moduleB.order){
+            return moduleA.order - moduleB.order;
         }
     }
     // If no order implemented or is the same, order by name
-    return moduleA.name > moduleB.name ? 1: -1;
+    return moduleA.name.localeCompare(moduleB.name);
 }
 export function brUtilsGeneralProvider() {
-    return { 
-        isNonEmpty, 
+    return {
+        isNonEmpty,
         capitalize,
         uiModuleComparator
     };


### PR DESCRIPTION
Allows to set up an order for listing the modules in the home page and the header menu. Also it renames the `App inspector` to just `Inspector` as it Apache Brooklyn can manage more than applications. 