### PR TITLE
WIP: Added logic to check extra contraints

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -565,7 +565,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                                     }
                                     break;
                                 case 'length':
-                                    if (!isSet() || isSet() && val().length === constrVals[0]) {
+                                    if (!isSet() || isSet() && val().length !== constrVals[0]) {
                                         message = `<samp>${config.name}</samp> must be of length (${constrVals[0]})`;
                                     }
                                     break;
@@ -576,7 +576,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                                     break;
                                 case 'max_length':
                                     if (!isSet() || isSet() && val().length > constrVals[0]) {
-                                        message = `length of <samp>${config.name}</samp> must be at max (${constrVals[0]})`;
+                                        message = `length of <samp>${config.name}</samp> must be at most (${constrVals[0]})`;
                                     }
                                     break;
                                 case 'pattern':


### PR DESCRIPTION
Added logic to check extra constraints and show error messages for them. 
1) Since the list of constraints is based on types that do not exist in Brooklyn, an impromevent of this would be to actually add those types in Brooklyn.
2) Transforming this bit of code into an extension and moving it to the dependent project looks like a pain to me, however if desired I am sure it is possible. 

Cheers!