### PR TITLE
When an entity don't have a name, it shows the personalised entity `ID`

### DIFF
--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -26,7 +26,8 @@
 <section class="spec-type container-fluid panel-group">
   <div class="panel">
     <div class="spec-type-header">
-        <h2 class="spec-title"><input class="form-control editable" ng-model="model.name" placeholder="{{model.miscData.get('typeName') || 'Unnamed ' + (!model.hasParent() ? 'application' : model.family.displayName)}}" blur-on-enter /></h2>
+        <h2 class="spec-title"><input class="form-control editable" ng-model="model.name" blur-on-enter
+            placeholder="{{model.id ? model.id :(model.miscData.get('typeName') || 'Unnamed ' + (!model.hasParent() ? 'application' : model.family.displayName))}}"/></h2>
 
         <div class="btn-group pull-right spec-actions" ng-if="model.hasType()" uib-dropdown>
             <button id="spec-actions" type="button" class="btn btn-link" uib-dropdown-toggle>


### PR DESCRIPTION
When an entity don't have a name, it shows the entity `ID` only when is provided instead the `typeName`

If no ID is provided it still shows the `typeName` instead the interal generated id as is shown in the `id` field

https://user-images.githubusercontent.com/17095501/173815479-0b4f422a-7b9e-482d-a3ce-0e96b5d059b3.mov

