### PR TITLE
Improve handling of spec types in composer

### DIFF
--- a/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
+++ b/ui-modules/blueprint-composer/app/components/designer/designer.directive.js
@@ -27,7 +27,6 @@ import {graphicalEditEnricherState} from '../../views/main/graphical/edit/enrich
 
 const MODULE_NAME = 'brooklyn.components.designer';
 const TEMPLATE_URL = 'blueprint-composer/component/designer/index.html';
-const ANY_MEMBERSPEC_REGEX = /(^.*[m,M]ember[s,S]pec$)/;
 const TAG = 'DIRECTIVE :: DESIGNER :: ';
 
 angular.module(MODULE_NAME, [])

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import angular from 'angular';
-import {Entity, EntityFamily} from "../util/model/entity.model";
+import {Entity, EntityFamily, DSL} from "../util/model/entity.model";
 import {Issue, ISSUE_LEVEL} from '../util/model/issue.model';
 import {Dsl} from "../util/model/dsl.model";
 import jsYaml from "js-yaml";
@@ -33,7 +33,7 @@ angular.module(MODULE_NAME, [])
 export default MODULE_NAME;
 
 export const RESERVED_KEYS = ['name', 'location', 'locations', 'type', 'services', 'brooklyn.config', 'brooklyn.children', 'brooklyn.enrichers', 'brooklyn.policies'];
-export const DSL_ENTITY_SPEC = '$brooklyn:entitySpec';
+export const DSL_ENTITY_SPEC = DSL.ENTITY_SPEC;
 
 export const COMMON_HINTS = {
     'config-quick-fixes': [{
@@ -723,7 +723,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
         // copy config key definitions set on this entity into the miscData aggregated view
         let allConfig = entity.miscDataOrDefault('configMap', {});
         entity.config.forEach((value, key) => {
-            entity.addConfigKeyDefinition(key, false, true);
+            entity.addConfigKeyDefinition(key, false, true, value);
         });
         entity.addConfigKeyDefinition(null, false, false);
     }

--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -546,9 +546,11 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
     function refreshConfigMemberspecsMetadata(entity) {
         let promiseArray = [];
         Object.values(entity.getClusterMemberspecEntities()).forEach((memberSpec)=> {
-            // memberSpec can be `undefined` if the member spec is not a `$brooklyn:entitySpec`, e.g. it is `$brooklyn:config("spec")`.
-            // there may be a better way but this seems to handle it.
-            if (memberSpec) promiseArray.push(refreshBlueprintMetadata(memberSpec, 'SPEC'));
+            // memberSpec can be `undefined` if the member spec is not a `$brooklyn:entitySpec`, e.g. it is `$brooklyn:config("spec")`;
+            // only process for the former type
+            if (memberSpec instanceof Entity) {
+                promiseArray.push(refreshBlueprintMetadata(memberSpec, 'SPEC'));
+            }
         });
         return $q.all(promiseArray);
     }
@@ -619,7 +621,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                     resolve(parsed);
                 }
             } catch (ex) {
-                $log.debug("Cannot detect whether this is a DSL expression; assuming not: " + input, ex);
+                $log.debug("Cannot detect whether this is a DSL expression; assuming not", input, ex);
                 reject(ex, input);
             }
         });

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -20,7 +20,7 @@ import angular from 'angular';
 import onEnter from 'brooklyn-ui-utils/on-enter/index';
 import autoGrow from 'brooklyn-ui-utils/autogrow/index';
 import blurOnEnter from 'brooklyn-ui-utils/blur-on-enter/index';
-import {EntityFamily, baseType, Entity} from '../util/model/entity.model';
+import {EntityFamily, baseType} from '../util/model/entity.model';
 import {Dsl} from '../util/model/dsl.model';
 import {Issue, ISSUE_LEVEL} from '../util/model/issue.model';
 import {RESERVED_KEYS, DSL_ENTITY_SPEC} from '../providers/blueprint-service.provider';
@@ -35,7 +35,6 @@ import { get } from 'lodash';
 import {graphicalEditEntityState} from "../../views/main/graphical/edit/entity/edit.entity.controller";
 
 const MODULE_NAME = 'brooklyn.components.spec-editor';
-const ANY_MEMBERSPEC_REGEX = /(^.*[m,M]ember[s,S]pec$)/;
 const REPLACED_DSL_ENTITYSPEC = '___brooklyn:entitySpec';
 const SUBSECTION = {
     CONFIG: 'config',
@@ -515,7 +514,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
             return scope.model.issues
                 .filter((issue) => (issue.group === groupName))
                 .concat(Object.values(scope.model.getClusterMemberspecEntities())
-                    .filter((spec) => (spec && spec.hasIssues()))
+                    .filter((spec) => (spec && spec.hasIssues && spec.hasIssues()))
                     .reduce((acc, spec) => (acc.concat(spec.issues)), []));
         }
 
@@ -934,7 +933,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 return value;
             }
 
-            if (ANY_MEMBERSPEC_REGEX.test(key) && value.hasOwnProperty(DSL_ENTITY_SPEC)) {
+            if (value.hasOwnProperty(DSL_ENTITY_SPEC)) {
                 let wrapper = {};
                 wrapper[REPLACED_DSL_ENTITYSPEC] = value[DSL_ENTITY_SPEC];
                 return wrapper;
@@ -1055,7 +1054,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
                 if (angular.isUndefined(localConfig[keyRef]) || localConfig[keyRef] === null || localConfig[keyRef].length < 1) {
                     continue;
                 }
-                if (ANY_MEMBERSPEC_REGEX.test(keyRef) && localConfig[keyRef].hasOwnProperty(REPLACED_DSL_ENTITYSPEC)) {
+                if (localConfig[keyRef].hasOwnProperty(REPLACED_DSL_ENTITYSPEC)) {
                     result[keyRef] = {};
                     result[keyRef][DSL_ENTITY_SPEC] = localConfig[keyRef][REPLACED_DSL_ENTITYSPEC];
                     continue;

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.less
@@ -22,6 +22,10 @@
 @hide-info-button-when-not-hovered: false;
 @hide-unset-undefault-values: true;
 
+@gray-lightish: mix(@gray-light, @gray-lighter, 50%);
+@brand-primary-darkish: mix(@brand-primary, @gray, 50%);
+@brand-primary-lightish: mix(@brand-primary, @gray-lighter, 50%);
+
 spec-editor {
   display: block;
   margin-top: 15px;
@@ -164,11 +168,18 @@ spec-editor {
       }
     }
     
-    &:hover .media-body {
+    &:hover {
+      .media-body {
         background-color: @gray-lighter;
+
         .remove-spec-adjunct, .update-spec-adjunct {
-            display: block;  // make visible on hover
+          display: block; // make visible on hover
         }
+      }
+      &.config-entity-spec .media-body {
+        // gray looks bad in the config editor
+        background-color: @brand-primary-lightish;
+      }
     }
   }
 
@@ -307,7 +318,7 @@ spec-editor {
             i {
                 // style changes below subtle but does a bit to make it look less clickable
                 border: 1px solid @gray;
-                color: @gray-light;
+                color: mix(@gray-light, @gray-lighter, 30%);
             }
         }
     }
@@ -330,7 +341,7 @@ spec-editor {
         margin-right: 1ex;
         text-align: center;
         .fa-info-circle {
-          color: mix(@gray-light, @gray-lighter, 50%);
+          color: @gray-lightish;
           transition: color 0.3s ease;
           &:hover {
             color: @brand-primary;
@@ -589,7 +600,7 @@ spec-editor {
             height: auto;
             margin-top: 2px;
             margin-bottom: 2px;
-            color: mix(@brand-primary, @gray);
+            color: @brand-primary-darkish;
           }
           select {
             padding-bottom: 1px;
@@ -603,7 +614,7 @@ spec-editor {
     }
     
     .no-spec {  // spec needs to be selected
-      border: 3px dashed @gray-lighter;
+      border: 3px dashed @gray-lightish;
       padding: 3px;
       display: block;
       color: @gray;
@@ -611,7 +622,7 @@ spec-editor {
       font-style: italic;
       transition: background-color 0.1s ease;
       &:hover {
-        background-color: @gray-lighter;
+        background-color: @brand-primary-lightish;
       }
     }
 

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -550,7 +550,7 @@
                         </div>
 
                         <div ng-switch-when="org.apache.brooklyn.api.entity.EntitySpec" ng-init="adjunct = config[item.name][REPLACED_DSL_ENTITYSPEC]">
-                            <div class="spec-adjunct" ng-if="config[item.name][REPLACED_DSL_ENTITYSPEC]">
+                            <div class="config-entity-spec spec-adjunct" ng-if="config[item.name][REPLACED_DSL_ENTITYSPEC]">
                                 <a ui-sref="main.graphical.edit.spec({entityId: model._id, specId: adjunct._id})"
                                             class="open-entity-spec"
                                             title="Open in spec editor"

--- a/ui-modules/blueprint-composer/app/components/util/model/dsl.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/dsl.model.js
@@ -50,8 +50,9 @@ export const KIND = {
     ENTITY  : {family: FAMILY.REFERENCE, name: 'entity object'},
     STRING  : {family: FAMILY.CONSTANT,  name: 'constant string'},
     NUMBER  : {family: FAMILY.CONSTANT,  name: 'constant number'},
-    OTHER   : {family: FAMILY.CONSTANT,  name: 'constant other'},
+    BOOLEAN : {family: FAMILY.CONSTANT,  name: 'constant boolean'},
     PORT    : {family: FAMILY.CONSTANT,  name: 'constant port'},
+    OTHER_CONST : {family: FAMILY.CONSTANT,  name: 'constant other'},
 };
 
 const ID = new WeakMap();
@@ -685,16 +686,15 @@ export class DslParser {
         if (this.s instanceof String || typeof this.s === 'string') {
             return this.parseString(this.s.toString().trim(), entity, entityResolverOrRoot);
         }
-        // NUMBER and OTHER kinds are in the CONSTANT family which means they aren't DSL expressions
-        // (API here could be improved!)
+        // NUMBER, BOOLEAN, OTHER_CONST kinds are in the CONSTANT family which means they aren't DSL expressions
         if (typeof this.s === 'number') {
             return new Dsl(KIND.NUMBER, this.s)
         }
         if (typeof this.s === 'boolean') {
-            return new Dsl(KIND.OTHER, this.s)
+            return new Dsl(KIND.BOOLEAN, this.s)
         }
-        // TODO support JSON objects (when YAML syntax supplied, eg object or entitySpec)
-        throw new DslError("Unable to parse: " + typeof this.s);
+        // TODO we could look at objects, nulls, etc, but right now we only parse DSL as string
+        return new Dsl(KIND.OTHER_CONST, this.s)
     }
 
     /**

--- a/ui-modules/blueprint-composer/app/components/util/model/dsl.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/dsl.model.js
@@ -693,7 +693,7 @@ export class DslParser {
         if (typeof this.s === 'boolean') {
             return new Dsl(KIND.OTHER, this.s)
         }
-        // TODO support JSON objects (for YAML syntax)
+        // TODO support JSON objects (when YAML syntax supplied, eg object or entitySpec)
         throw new DslError("Unable to parse: " + typeof this.s);
     }
 

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -649,8 +649,6 @@ Entity.prototype.resetIssues = resetIssues;
 Entity.prototype.delete = deleteEntity;
 Entity.prototype.reset = resetEntity;
 
-// TODO remove the DSL errors on object?
-
 function isTypeForSpec(typeName) {
     return typeName && typeName.startsWith && typeName.startsWith("org.apache.brooklyn.api.entity.EntitySpec")
 }

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.spec.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.spec.js
@@ -16,8 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {Entity, EntityFamily, PREDICATE_MEMBERSPEC, PREDICATE_FIRST_MEMBERSPEC} from "./entity.model";
+import {Entity, EntityFamily, PREDICATE_MEMBERSPEC} from "./entity.model";
 import {Issue} from './issue.model';
+
+const FIRST_MEMBERSPEC_REGEX = /^(\w+\.)*first[mM]ember[sS]pec$/;
+export const PREDICATE_FIRST_MEMBERSPEC = (config, entity)=>(config.name.match(FIRST_MEMBERSPEC_REGEX));
+
 
 describe('Brooklyn Model', ()=> {
 

--- a/ui-modules/utils/autogrow/index.js
+++ b/ui-modules/utils/autogrow/index.js
@@ -48,7 +48,7 @@ export function autoGrowDirective() {
         }
         let update = () => {
             const text = ctrl.$modelValue || '';
-            element[0].rows = Math.min(1 + (text.match(/\n/g) || []).length, maxRows);
+            element[0].rows = Math.min(1 + (text.toString().match(/\n/g) || []).length, maxRows);
             setClass(element, 'auto-grow-single-row', element[0].rows == 1);
             setClass(element, 'auto-grow-multi-row', element[0].rows > 1);
         };


### PR DESCRIPTION
Previously we used regex on key names to determine if the contents was an entity spec.  This meant some (eg multi-group) didn't work and in some cases could make the UI unusable or broken.

This checks the actual type defined for the key name and of the value if the type is Object and so supports entity spec

either if:
- it uses the DSL word
- the key type matches
- the key name matches (fallback for where type is unknown/not-loaded and value not set)

and in multiple places:
- in model
- in designer view canvas
- in spec editor

Also makes minor related improvements to UI and code.