### PR TITLE
don't hard-code a version in composer unless explicitly set

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -748,7 +748,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
             return result;
         }
         entity.clearIssues({group: 'type'});
-        entity.version = data.version;
+
         entity.type = data.symbolicName;
         entity.icon = entity.metadata.get('iconUrl')
             ? (data.iconUrl || '/v1/catalog/types/'+entity.type+'/'+(entity.version || 'latest')+'/icon')+'?iconUrl='+entity.metadata.get('iconUrl')
@@ -771,6 +771,8 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
         entity.miscData.set('sensors', data.sensors || []);
         entity.miscData.set('traits', data.supertypes || []);
         entity.miscData.set('tags', data.tags || []);
+        entity.miscData.set('loadedVersion', data.version);
+
         data.tags.forEach( (t) => {
             mergeAppendingLists(COMMON_HINTS, t['ui-composer-hints']);
         });

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.directive.js
@@ -146,6 +146,7 @@ export function specEditorDirective($rootScope, $templateCache, $injector, $sani
         specEditor.addParameter = addParameter;
         specEditor.removeParameter = removeParameter;
         specEditor.setEntityVersion = setEntityVersion;
+        specEditor.loadedVersion = () => scope.model.miscData.get('loadedVersion') || 'unknown';
 
         const defaultState = {
             availableVersions: [],

--- a/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
+++ b/ui-modules/blueprint-composer/app/components/spec-editor/spec-editor.template.html
@@ -59,12 +59,17 @@
                 <div ng-if="state.availableVersions.length > 0" class="version-selection">
                     <i class="fa fa-code-fork panel-header-icon"></i>
                     <div class="btn-group" uib-dropdown dropdown-append-to-body>
-                        <button type="button" class="btn btn-primary fixed">{{state.selectedVersion}}</button>
+                        <button type="button" class="btn btn-primary fixed">{{state.selectedVersion || '('+specEditor.loadedVersion()+')'}}</button>
                         <button type="button" class="btn btn-primary" uib-dropdown-toggle>
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu versions" uib-dropdown-menu role="menu" aria-labelledby="btn-append-to-body">
                             <li role="separator" class="divider no-margin"></li>
+                            <li role="menuitem">
+                                <a href="#" ng-click="$event.preventDefault();specEditor.setEntityVersion(null)">
+                                    Use default version
+                                </a>
+                            </li>
                             <li ng-repeat="version in state.availableVersions" role="menuitem">
                                 <a href="#" ng-click="$event.preventDefault();specEditor.setEntityVersion(version)">
                                     {{version}}

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -180,7 +180,7 @@ export class Entity {
      * @returns {boolean}
      */
     hasVersion() {
-        return MISC_DATA.get(this).has('version');
+        return MISC_DATA.get(this).has('version') && MISC_DATA.get(this).get('version');
     }
 
     /**


### PR DESCRIPTION
versions set either in the yaml or by a user in the dropdown are fixed.
otherwise no version is stored.
fixes bad behaviour where previously, switching to composer would hard-code versions everywhere, _changing_ the blueprint (introduced in #292)