### PR TITLE
fix issues around quick fixes

### DIFF
--- a/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
+++ b/ui-modules/blueprint-composer/app/components/providers/blueprint-service.provider.js
@@ -346,6 +346,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
             entity.miscData.set('loading', false);
             return refreshRelationships(entity);
         }).then(() => {
+            entity.clearIssues({group: 'config'});
             return $q.all([
                 refreshConfigConstraints(entity),
                 refreshConfigMemberspecsMetadata(entity),
@@ -603,7 +604,7 @@ function BlueprintService($log, $q, $sce, paletteApi, iconGenerator, dslService,
                             .group('config')
                             .ref(definition.name)
                             .level(ISSUE_LEVEL.WARN)
-                            .message(`Implicitly defined from one of its ancestor`)
+                            .message(`Implicitly defined (inherited from an ancestor)`)
                             .build());
                     }
                 });

--- a/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
+++ b/ui-modules/blueprint-composer/app/components/util/model/entity.model.js
@@ -1053,7 +1053,7 @@ function hasIssues() {
     return this.issues.length > 0;
 }
 
-function clearIssues(predicate) {
+function clearIssues(predicate, recursive) {
     if (this.hasIssues()) {
         if (predicate && predicate instanceof Object) {
             MISC_DATA.get(this).set('issues', this.issues.filter(issue => {
@@ -1069,6 +1069,9 @@ function clearIssues(predicate) {
             this.resetIssues();
         }
         this.touch();
+    }
+    if (recursive) {
+        this.children.forEach(child => child.clearIssues(predicate, recursive));
     }
     return this;
 }

--- a/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
+++ b/ui-modules/blueprint-composer/app/views/main/graphical/graphical.state.less
@@ -137,6 +137,7 @@
     }
     .error-line-text {
       flex: 1 1 auto;
+      margin-top: 4px;   // match marker
     }
     .error-line-marker {
       color: @brand-danger;


### PR DESCRIPTION
- reference to ancestor without ID caused null, now it sets the id
- reference to ancestor fix always just pointed at parent, not where config was defined
- count of errors was sometimes not reset so was too high
- alignment of error line marker was wrong