### PR TITLE
fix non-unique properties not being included

### DIFF
--- a/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
+++ b/ui-modules/blueprint-composer/app/components/dsl-editor/dsl-editor.js
@@ -307,7 +307,7 @@ export function dslEditorDirective($rootScope, $filter, $log, brUtilsGeneral, bl
 
         // filtering with both own and parent's ID in case we have same-type child nodes
         return items.filter(({ id, entity }) => {
-            const marker = id + ':' + (entity.id || '-');
+            const marker = id + ':' + (entity.id || entity._id || '-');
             if (IDs.has(marker)) return false;
             IDs.add(marker);
             return true;


### PR DESCRIPTION
fix for using the entity id properly to include all entities properties (previously wrongly removed as non-unique):

* The problem happens when there are multiple entities of the same type. When filtering by entities, we can see that only the one that was added first has all items, the others only have a single item - the entity itself
* there is a function in dsl-editor.js - uniqueItemsthat filters items based on the name of prop and entity id.  This function gets called by three distinct categories: config, sensors and entities (functions getConfigItems,getSensorItems and getEntityItems  respectively)
* When calling in from the entity, the property entity.id is present, hence we get the entity itself in the list
* However, when called via sensors/config, the entity.id is undefined (the entity object only appears to have 2 props - lastUpdatedTime and isDslEdit ) and hence - is passed instead of correct id and items are not added.
* Changing the property to lastUpdatedTime has solved the issue but not the best approach imo
* My idea was to try and add the id to the entity object (returned by blueprintservice), but digging down and debugging the recursive function etc, we eventually figured out that there is an _id property that has the right id and that helped to fix the issue