### PR TITLE
fix for missing version in 'View in Catalog' link

### DIFF
--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
@@ -208,7 +208,8 @@ export function CatalogItemModalController($scope, $filter, blueprintService, pa
     };
 
     $scope.getCatalogURL = () => {
-        const urlPartVersion = $scope.config.current.version || $scope.config.version;
+        const urlPartVersion = _.get($scope, 'config.current.version') || _.get($scope, 'config.version');
+        if (!urlPartVersion) return "";
 
         switch ($scope.state.view) {
             case VIEWS.form:

--- a/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
+++ b/ui-modules/blueprint-composer/app/components/catalog-saver/catalog-saver.directive.js
@@ -208,12 +208,14 @@ export function CatalogItemModalController($scope, $filter, blueprintService, pa
     };
 
     $scope.getCatalogURL = () => {
+        const urlPartVersion = $scope.config.current.version || $scope.config.version;
+
         switch ($scope.state.view) {
             case VIEWS.form:
                 return '';
             case VIEWS.saved:
                 // TODO where do these come from
-                return `/brooklyn-ui-catalog/#!/bundles/${$scope.config.catalogBundleId}/${$scope.config.version}/types/${$scope.config.catalogBundleSymbolicName}/${$scope.config.version}`;
+                return `/brooklyn-ui-catalog/#!/bundles/${$scope.config.catalogBundleId}/${urlPartVersion}/types/${$scope.config.catalogBundleSymbolicName}/${urlPartVersion}`;
         }
     };
 


### PR DESCRIPTION
Refactoring to avoid regression from previous changes that caused the "version" URL components of this link to be `undefined`.