### PR TITLE
Tidies layout of new-policy screen

### DIFF
--- a/ui-modules/app-inspector/app/views/main/inspect/management/management.less
+++ b/ui-modules/app-inspector/app/views/main/inspect/management/management.less
@@ -52,10 +52,7 @@
 .add-new-policy {
     border: 1px solid fade(@brand-primary, 41%);
     background: @primary-5;
-    padding-left: 20px;
-    padding-right: 20px;
-    padding-top: 20px;
-    padding-bottom: 20px;
+    padding: 0px;
     margin-bottom: 20px;
 
     h3 {
@@ -109,6 +106,12 @@
                 stroke: darken(#5ab959, 15%);
             }
         }
+    }
+
+    .modal-footer {
+        display: flex;
+        justify-content: end;
+        gap: 1em;
     }
 }
 


### PR DESCRIPTION
Tidies the new policy layout screen to remove the excess padding and align the buttons correctly

Before:
<img width="728" alt="Screenshot 2023-04-03 at 11 47 16" src="https://user-images.githubusercontent.com/1488244/229488407-705b6199-ac1b-495c-b0c5-56a400ecb04d.png">

After:
<img width="728" alt="Screenshot 2023-04-03 at 11 47 44" src="https://user-images.githubusercontent.com/1488244/229488419-0be1b756-2540-4864-a42c-b91d476ae8c7.png">
