### PR TITLE
Added check that parsedPlan.services exists before checking its length

### DIFF
--- a/ui-modules/utils/quick-launch/quick-launch.js
+++ b/ui-modules/utils/quick-launch/quick-launch.js
@@ -160,7 +160,7 @@ export function quickLaunchDirective() {
                     result[config.name] = config;
 
                     let configValue = (parsedPlan[BROOKLYN_CONFIG] || {})[config.name];
-                    if (typeof configValue == 'undefined' && parsedPlan.services.length==1) {
+                    if (typeof configValue === 'undefined' &&  parsedPlan.services && parsedPlan.services.length === 1) {
                         configValue = (parsedPlan.services[0] && parsedPlan.services[0][BROOKLYN_CONFIG] || {})[config.name];
                     }
 


### PR DESCRIPTION
Added check that parsedPlan.services exists before checking its length, which would be causing an issue for extensions that fo not have a `parsedPlan.services`