### PR TITLE
Brooklyn UI avoid entity name wrap pt 184904842

### DIFF
--- a/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
+++ b/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
@@ -124,4 +124,30 @@ a.blueprint-button {
   font-style: italic;
 }
 
+.tooltip {
+  position: absolute;
+  display: inline-block;
+  opacity: 100%;
+}
+
+.tooltip .tooltiptext {
+  background-color: #e3f5db;;
+  color: inherit;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  /* Position the tooltip text - see examples below! */
+  z-index: 1;
+}
+
+.tooltiptext {
+  opacity: 0;
+  transition: opacity 0.5s;
+}
+
+.tooltip:hover .tooltiptext {
+  opacity: 1;
+}
+
+
 .modal-dialog .modal-header .text-danger:extend(.text-danger) {}

--- a/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
+++ b/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
@@ -128,6 +128,7 @@ a.blueprint-button {
   position: relative;
   display: inline-block;
   opacity: 1;
+  top: 25px;
   filter: drop-shadow(5px 5px 4px #b3c5ab);
 }
 

--- a/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
+++ b/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
@@ -39,6 +39,7 @@
       .node-name {
         flex: 1 0 200px;
         border: none;
+        .text-overflow();
       }
       .editable-wrap {
         flex: 1 0 200px;

--- a/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
+++ b/ui-modules/app-inspector/app/views/main/inspect/summary/summary.less
@@ -125,22 +125,20 @@ a.blueprint-button {
 }
 
 .tooltip {
-  position: absolute;
+  position: relative;
   display: inline-block;
-  opacity: 100%;
+  opacity: 1;
+  filter: drop-shadow(5px 5px 4px #b3c5ab);
 }
 
 .tooltip .tooltiptext {
-  background-color: #e3f5db;;
-  color: inherit;
-  text-align: center;
-  padding: 5px 0;
+  background-color: #e3f5db;
   border-radius: 6px;
-  /* Position the tooltip text - see examples below! */
   z-index: 1;
 }
 
 .tooltiptext {
+  position: absolute;
   opacity: 0;
   transition: opacity 0.5s;
 }

--- a/ui-modules/app-inspector/app/views/main/inspect/summary/summary.template.html
+++ b/ui-modules/app-inspector/app/views/main/inspect/summary/summary.template.html
@@ -23,6 +23,9 @@
             <h2 ng-if="vm.entity" class="entity-name">
               <span class="node-icon"><img ng-src="{{ vm.iconUrl }}"/></span>
               <span class="node-name" editable-text="vm.name" blur="submit" buttons="no" blur="submit" onaftersave="vm.updateEntityName()">{{ vm.entity.name }}</span>
+              <span class="tooltip">
+                  <span class="tooltiptext">{{ vm.entity.name }}</span>  
+              </span>
             </h2>
         </div>
         <p ng-if="vm.sensors['main.uri']">

--- a/ui-modules/app-inspector/app/views/main/inspect/summary/summary.template.html
+++ b/ui-modules/app-inspector/app/views/main/inspect/summary/summary.template.html
@@ -20,12 +20,12 @@
     <div class="tab-header">
         <div class="entity-header">
             <h2 ng-if="!vm.entity" class="entity-name loading"><loading-state error="vm.error.entity"></loading-state></h2>
+              <span ng-if="vm.entity" class="tooltip">
+                  <span class="tooltiptext">{{ vm.entity.name }}</span>  
+              </span>
             <h2 ng-if="vm.entity" class="entity-name">
               <span class="node-icon"><img ng-src="{{ vm.iconUrl }}"/></span>
               <span class="node-name" editable-text="vm.name" blur="submit" buttons="no" blur="submit" onaftersave="vm.updateEntityName()">{{ vm.entity.name }}</span>
-              <span class="tooltip">
-                  <span class="tooltiptext">{{ vm.entity.name }}</span>  
-              </span>
             </h2>
         </div>
         <p ng-if="vm.sensors['main.uri']">


### PR DESCRIPTION
Changes overflow behaviour on entity name to ellipsis instead of overflow
Adds a tooltip showing the full name on hover
<img width="1097" alt="Screenshot 2023-04-12 at 16 17 30" src="https://user-images.githubusercontent.com/21359664/231505741-0141ead2-2814-450e-b269-1607a2a07e24.png">
<img width="1101" alt="Screenshot 2023-04-12 at 16 17 20" src="https://user-images.githubusercontent.com/21359664/231505764-1ff6d097-da8b-402c-aa76-617ea7004350.png">
