### PR TITLE
wrapping long step id text

### DIFF
--- a/ui-modules/app-inspector/app/components/workflow/workflow-steps.less
+++ b/ui-modules/app-inspector/app/components/workflow/workflow-steps.less
@@ -63,6 +63,7 @@
         font-size: 80%;
         flex: 5 1 auto;
         background-color: @primary-50;
+        white-space: normal;
 
         &.handy {
           cursor: pointer;


### PR DESCRIPTION
This should fix issues with displaying long IDs for workflow steps without them escaping the panel:

![workflow-item-wrapping](https://user-images.githubusercontent.com/8679925/231720612-fd7d9aa8-7dc4-4e00-8cb1-ef11f038ad74.png)
