### PR TITLE
Added clickable URLs, that open in a new tab for imported types, adde…

### DIFF
--- a/ui-modules/utils/catalog-uploader/catalog-uploader.html
+++ b/ui-modules/utils/catalog-uploader/catalog-uploader.html
@@ -20,7 +20,7 @@
     <i class="fa fa-times target-close pull-right" ng-click="close()"></i>
     <div class="container">
         <div class="row">
-            <div class="col-sm-12 text-center">
+            <div class="col-sm-8 text-center">
                 <p><i class="fa fa-3x fa-upload"></i></p>
                 <p>
                     <input type="file" name="files" id="files" multiple custom-on-change="filesChanged" />
@@ -30,7 +30,7 @@
         </div>
 
         <div class="row">
-            <div class="col-sm-12 text-muted upload-item" ng-repeat="selectedFile in selectedFiles" ng-init="isDetailsCollapsed = true">
+            <div class="col-sm-8 text-muted upload-item" ng-repeat="selectedFile in selectedFiles" ng-init="isDetailsCollapsed = true">
                 <div class="progress">
                     <div class="progress-bar progress-bar-striped" role="progressbar" ng-class="{'active': !selectedFile.error && !selectedFile.result, 'progress-bar-danger': selectedFile.error, 'progress-bar-success': selectedFile.result}" style="width: 100%">
                         <span ng-if="!selectedFile.result && !selectedFile.error">Importing</span> {{selectedFile.name}}
@@ -42,12 +42,20 @@
                         <ul class="fa-ul">
                             <li ng-repeat="(key, item) in selectedFile.result track by key">
                                 <i class="fa-li fa fa-check-square"></i>
-                                <a ng-href="{{getCatalogItemUrl(item)}}">{{item.itemType}} {{item.symbolicName}}:{{item.version}}</a>
+                                <a ng-href="{{getCatalogItemUrl(item)}}" target="_blank">{{item.itemType}} {{item.symbolicName}}:{{item.version}}</a>
                             </li>
                         </ul>
                     </p>
                     <p ng-if="selectedFile.error">{{selectedFile.error}}</p>
                 </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-8 text-left">
+                <button class="btn btn-success" ng-click="close()">
+                    <i class="fa fa-fw fa-arrow-circle-left"></i>
+                    Return to catalog
+                </button>
             </div>
         </div>
     </div>

--- a/ui-modules/utils/catalog-uploader/catalog-uploader.js
+++ b/ui-modules/utils/catalog-uploader/catalog-uploader.js
@@ -47,7 +47,7 @@ export default MODULE_NAME;
  * @description
  * Attaches an overlay on the current DOM element to handle file upload to the catalog. Files can either by added via
  * classic file selection or drag & drop. The overlay can be triggered by broadcasting an event: for this to work, the
- * event name need to be passed as value for the `brooklynCatalogUploader` attribute.
+ * event name needs to be passed as value for the `brooklynCatalogUploader` attribute.
  *
  * @param {string} brooklynCatalogUploader The value can be empty. Otherwise, the directive will listen for any event broadcasted
  * with this name and will trigger the overlay upon reception.
@@ -96,6 +96,7 @@ export function catalogUploaderDirective($compile, brooklynCatalogUploader) {
 
         scope.close = ()=> {
             counter--;
+            scope.selectedFiles = []; // clean up the imported file list on returning to catalog, still needs a manual refresh to show the imported bundle
             element.removeClass('br-drag-active');
         };
 


### PR DESCRIPTION
Added:

-  clickable URLs, that open in a new tab for imported types
-  a 'Return to Catalog' button in the bundle upload dialog page
-  cleaned up the list of imported types on returning to catalog

Notes: would be nice if the `Return to Catalog` button would redirect to the imported bundle page. 
<img width="727" alt="Screenshot 2024-06-19 at 11 45 35" src="https://github.com/apache/brooklyn-ui/assets/2484724/4365cd02-b347-49a2-97c6-63a4cf3b38d4">

