### PR TITLE
minor changes in logbook ui

### DIFF
--- a/ui-modules/utils/logbook/logbook.js
+++ b/ui-modules/utils/logbook/logbook.js
@@ -68,6 +68,7 @@ export function logbook() {
         $scope.waitingResponse = false;
         $scope.logtext = '';
         $scope.wordwrap = true;
+        $scope.showOptions = false;
         $scope.logEntries = [];
         $scope.minNumberOfItems = 1;
         $scope.maxNumberOfItems = 10000;
@@ -86,7 +87,8 @@ export function logbook() {
             dateTimeFrom: null,
             dateTimeTo: null,
             numberOfItems: 1000,
-            phrase: ''
+            phrase: '',
+            loggerName: ''
         };
 
         // Define search result filters.
@@ -237,6 +239,7 @@ export function logbook() {
                 tail: $scope.search.latest,
                 recursive: $scope.search.recursive,
                 searchPhrase: $scope.search.phrase,
+                loggerName: $scope.search.loggerName,
                 taskId: $scope.taskId,
                 entityId: $scope.entityId,
                 numberOfItems: $scope.search.numberOfItems,

--- a/ui-modules/utils/logbook/logbook.template.html
+++ b/ui-modules/utils/logbook/logbook.template.html
@@ -19,22 +19,11 @@
 
 <form class="form-group">
     <div class="row">
-        <div class="col-md-2">
-            <label for="dateTimeFrom">Query from:</label>
-            <input id="dateTimeFrom" type="datetime-local" ng-model="search.dateTimeFrom" class="form-control">
-        </div>
-        <div class="col-md-2">
-            <label for="dateTimeTo">Query to:</label>
-            <input id="dateTimeTo" type="datetime-local" ng-model="search.dateTimeTo" class="form-control">
-        </div>
-        <div class="col-md-2">
-            <label for="numberOfItems">Number of lines:</label>
-            <input id="numberOfItems" type="number" ng-model="search.numberOfItems" class="form-control" required placeholder="({{minNumberOfItems}} - {{maxNumberOfItems}})" min="{{minNumberOfItems}}" max="{{maxNumberOfItems}}">
-        </div>
-        <div class="col-md-6">
+        <div class="col-md-12">
             <label for="searchPhrase">Search phrase:</label>
             <div class="input-group">
-                <input id="searchPhrase" type="text" ng-model="search.phrase" class="form-control" placeholder="(None)">
+                <input id="searchPhrase" type="text" ng-model="search.phrase" class="form-control" placeholder="(None)"
+                       ng-keypress="$event.keyCode == 13 && !autoRefresh && vm.isValidNumber() && vm.singleQuery()">
                 <div class="input-group-btn">
                     <div class="btn-group">
                         <button ng-show="!autoRefresh" class="btn btn-default btn-primary" ng-click="vm.singleQuery()" ng-disabled="waitingResponse || autoRefresh || !vm.isValidNumber()">Query</button>
@@ -81,8 +70,32 @@
                             <i class="fa fa-rotate-180" ng-class="{'fa-align-right': wordwrap, ' fa-align-justify': !wordwrap}"></i>
                         </button>
                     </div>
+                    <div class="btn-group">
+                        <button type="button" ng-click="showOptions = !showOptions" class="btn btn-default btn-accent btn-logbook" uib-tooltip="{{showOptions ? 'Hide' : 'Show'}} additional options">
+                            <i class="fa fa-cog" ng-class="{'icon-inactive': !showOptions}"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
+        </div>
+    </div>
+    <div class="row" ng-show="showOptions" style="margin-top: 8px;">
+        <div class="col-md-3">
+            <label for="loggerName">Logger prefix:</label>
+            <input id="loggerName" type="text" ng-model="search.loggerName" class="form-control" placeholder="e.g. o.a.b.SSH"
+                   ng-keypress="$event.keyCode == 13 && !autoRefresh && vm.isValidNumber() && vm.singleQuery()">
+        </div>
+        <div class="col-md-3">
+            <label for="dateTimeFrom">Query from:</label>
+            <input id="dateTimeFrom" type="datetime-local" ng-model="search.dateTimeFrom" class="form-control">
+        </div>
+        <div class="col-md-3">
+            <label for="dateTimeTo">Query to:</label>
+            <input id="dateTimeTo" type="datetime-local" ng-model="search.dateTimeTo" class="form-control">
+        </div>
+        <div class="col-md-3">
+            <label for="numberOfItems">Number of lines:</label>
+            <input id="numberOfItems" type="number" ng-model="search.numberOfItems" class="form-control" required placeholder="({{minNumberOfItems}} - {{maxNumberOfItems}})" min="{{minNumberOfItems}}" max="{{maxNumberOfItems}}">
         </div>
     </div>
 </form>


### PR DESCRIPTION
* add a text field for logger name/class prefix filtering (separate CR to handle this in brooklyn-server)
* move the field above and also the date and number of lines filters to a separate line and make them be shown/hidden with the button 'show additonal options' added to the button pallette
<img width="1720" height="264" alt="Screenshot 2026-04-20 at 10 56 38" src="https://github.com/user-attachments/assets/2dfa0bef-ad49-4210-ace2-0ea34805a7b2" />
